### PR TITLE
Env fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ You can access the following services:
 
 - [`Prisma` GraphQL Playground](https://github.com/prisma/graphql-playground#how-is-this-different-from-graphiql): http://localhost:4466
 
+#### MySQL
+
+```
+docker exec -it "colrc-v2-mysql-db" mysql -u root -p
+```
+See [`misc/.env`](./misc/.env) for the credentials used to launch the development version of the service.
+
 ### Test
 
 We suggest testing using the environment launched by `docker-compose`.

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -20,11 +20,6 @@ services:
       - "3306"
     env_file:
       - ./misc/.env
-    environment:
-      # FIXME: Make DRY/unified with MySQL, Prisma, etc.
-      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-      MYSQL_DATABASE: ${DB_NAME}
-      MYSQL_USER: ${DB_USERNAME}
     volumes:
       - mysql:/var/lib/mysql
   backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.5'
 services:
   prisma:
+    container_name: colrc-v2-prisma
     image: prismagraphql/prisma:1.34
     restart: always
     depends_on:
@@ -14,17 +15,13 @@ services:
     volumes:
       - "./misc/prisma.yml:/prisma.yml"
   mysql:
+    container_name: colrc-v2-mysql-db
     image: mysql:5.7
     restart: always
     ports:
       - "3306:3306"
     env_file:
       - ./misc/.env
-    environment:
-      # FIXME: Make DRY/unified with MySQL, Prisma, etc.
-      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-      MYSQL_DATABASE: ${DB_NAME}
-      MYSQL_USER: ${DB_USERNAME}
     volumes:
       - mysql:/var/lib/mysql
   backend:

--- a/misc/.env
+++ b/misc/.env
@@ -1,4 +1,11 @@
+COMPOSE_PROJECT_NAME=colrc
 DB_NAME=colrc
 DB_PASSWORD=prisma
 DB_USERNAME=root
 JWT_SECRET=Mysecretpasscode
+# must match DB_PASSWORD
+MYSQL_ROOT_PASSWORD=prisma
+# must match DB_NAME
+MYSQL_DATABASE=colrc
+# must match DB_USERNAME
+MYSQL_USER=root


### PR DESCRIPTION
Previously the `environment` block was referencing variables unavailable to the shell, as they were only referenced in `misc/.env`.  These changes incorporate those variables in the `misc/.env` file, and do away with the `environment` block for services defined in `docker-compose.yml`.