### PR TITLE
Wait for DB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
-version: '3.5'
+version: "2.1"
 services:
   prisma:
     container_name: colrc-v2-prisma
     image: prismagraphql/prisma:1.34
-    restart: always
+    restart: on-failure
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     ports:
       - "4466:4466"
     env_file:
@@ -22,8 +23,14 @@ services:
       - "3306:3306"
     env_file:
       - ./misc/.env
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - mysql:/var/lib/mysql
+    healthcheck:
+        test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+        timeout: 20s
+        retries: 10
   backend:
     container_name: colrc-v2-backend
     build:
@@ -44,8 +51,6 @@ services:
       DB_HOST: mysql
     volumes:
       - ./backend:/app:rw
-      # prevent host's node_modules from being mounted
-      - /app/node_modules
   frontend:
     container_name: colrc-v2-frontend
     build:

--- a/misc/.env
+++ b/misc/.env
@@ -1,11 +1,14 @@
 COMPOSE_PROJECT_NAME=colrc
-DB_NAME=colrc
-DB_PASSWORD=prisma
+
 DB_USERNAME=root
+DB_PASSWORD=prisma
+DB_NAME=colrc
+
 JWT_SECRET=Mysecretpasscode
+
+# must match DB_USERNAME
+MYSQL_USER=root
 # must match DB_PASSWORD
 MYSQL_ROOT_PASSWORD=prisma
 # must match DB_NAME
 MYSQL_DATABASE=colrc
-# must match DB_USERNAME
-MYSQL_USER=root


### PR DESCRIPTION
`depends_on` does **not** only ensures the referenced service is running.  This change helps ensure mySQL is ready to accept connections.  Previously,  `prisma` would throw a connection error, as mySQL was not yet available.