### PR TITLE
Red error message box

### DIFF
--- a/frontend/src/affixes/AddAffix.js
+++ b/frontend/src/affixes/AddAffix.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Grid, Header, Message, Segment, Input } from 'semantic-ui-react';
+import { Button, Grid, Header, Message, Segment, Input, Label } from 'semantic-ui-react';
 import { Formik, Form } from 'formik';
 import * as Yup from 'yup';
 import SimpleKeyboard from "../utilities/SimpleKeyboard";
@@ -38,7 +38,7 @@ class AddAffix extends Component {
       console.log(result.graphQLErrors[0].message);
       setSubmitting(false)
       this.setState({ error: result.graphQLErrors[0].message });
-		}
+    }
 	};
 
 	render() {
@@ -46,7 +46,7 @@ class AddAffix extends Component {
       type: Yup.string()
         .max(150, 'cannot be more than 150 characters'),
       salish: Yup.string()
-        .max(150, 'cannot be more than 150 characters'),
+        .max(150, 'cannot exceed 150 characters'),
       nicodemus: Yup.string()
         .min(2, 'at least 2 characters are required')
         .required('an affix entry is required'),
@@ -61,7 +61,6 @@ class AddAffix extends Component {
         .max(150, 'cannot be more than 150 characters')
       });
 
-
 		return (
       <Grid textAlign='center'  verticalAlign='top'>
         <Grid.Column>
@@ -71,11 +70,9 @@ class AddAffix extends Component {
           <Message>
             Fill in the fields below to add a new affix to the list.  Any new affix must include an entry in the Nicodemus writing system, and an English translation.  Other fields are optional, and the layout of this list is based on Reichard 1938.  Links and pages show the affix in that publication.
           </Message>
-
           {this.state.error && (
-            <div className="input-feedback">{this.state.error}</div>
+          <Message className="error">Unsuccessful: {this.state.error}</Message>
           )}
-
           <Segment stacked>
           <Formik 
               initialValues={{ type: '', salish: '', nicodemus: '', english: '', link: '', page: '', editnote: ''}}
@@ -89,7 +86,7 @@ class AddAffix extends Component {
     						<Input 
                   fluid 
                   label={{ basic: true, color: 'blue', content: 'Type' }}
-    							placeholder='Including the affix type is optional...'
+    							placeholder='Including the affix type is optional.'
     							id='type'
                   type='text'
     							value={values.type}
@@ -97,13 +94,14 @@ class AddAffix extends Component {
                   onBlur={handleBlur}
                   className={ errors.type && touched.type ? 'text-input error' : 'text-input' }
                 />
+                <Label pointing>Including the affix type is optional.</Label>
                 {errors.type && touched.type && (
                 <div className="input-feedback">{errors.type}</div>
                 )}
                 <Input 
                   fluid 
                   label={{ basic: true, color: 'blue', content: 'Salish' }}
-                  placeholder='A transcription in the Salish orthography is optional'
+                  placeholder='A transcription in the Salish orthography is optional.'
                   id='salish'
                   type='text'
                   value={values.salish}
@@ -111,6 +109,7 @@ class AddAffix extends Component {
                   onBlur={handleBlur}
                   className={ errors.salish && touched.salish ? 'text-input error' : 'text-input' }
                 />
+                <Label pointing>A transcription in the Salish orthography is optional.</Label>
                 {errors.salish && touched.salish && (
                 <div className="input-feedback">{errors.salish}</div>
                 )}

--- a/frontend/src/affixes/EditAffix.js
+++ b/frontend/src/affixes/EditAffix.js
@@ -71,7 +71,6 @@ class EditAffix extends Component {
 	};
 
 	render() {
-    const { id, type, salish, nicodemus, english, link, page, editnote } = this.state.fields
     console.log("this.state.fields is")
     console.log(this.state.fields)
     const affixSchema = Yup.object().shape({
@@ -104,7 +103,7 @@ class EditAffix extends Component {
             Fill in the fields below to edit the selected affix.  When you save your edits, the old affix entry will be set to 'inactive' status and will no longer display.  The edited affix will display to users.  Please add an 'edit note' to briefly characterize the reason for the edit.  Edit notes do not display to users.
           </Message>
           {this.state.error && (
-            <div className="input-feedback">{this.state.error}</div>
+          <Message className="error">Unsuccessful: {this.state.error}</Message>
           )}
           <Segment stacked>
             <Formik
@@ -135,8 +134,6 @@ class EditAffix extends Component {
                   value={values.id}
                   onChange={handleChange}
                   onBlur={handleBlur}
-                  // There are no errors for incorrect ID input because it loads pre-filled anyway 
-                  className={ errors.type && touched.type ? 'text-input error' : 'text-input' }
                 />
                 <Input 
                   fluid 

--- a/frontend/src/roots/AddRoot.js
+++ b/frontend/src/roots/AddRoot.js
@@ -69,11 +69,9 @@ class AddRoot extends Component {
           <Message>
             Fill in the fields below to add a new root to the list.  Any new root must include an entry in the Nicodemus writing system, and an English translation.  Other fields are optional.
           </Message>
-
-					{this.state.error && (
-            <div className="input-feedback">{this.state.error}</div>
-					)}
-					
+          {this.state.error && (
+          <Message className="error">Unsuccessful: {this.state.error}</Message>
+          )}
 					<Segment stacked>
           <Formik 
               initialValues={{ root: '', number: '', salish: '', nicodemus: '', english: '', editnote: ''}}

--- a/frontend/src/roots/EditRoot.js
+++ b/frontend/src/roots/EditRoot.js
@@ -69,7 +69,6 @@ class EditRoot extends Component {
 	};
 
 	render() {
-		const { id, root, number, salish, nicodemus, english, editnote } = this.state.fields
     console.log("this.state.fields is")
     console.log(this.state.fields)
     const rootSchema = Yup.object().shape({
@@ -81,7 +80,7 @@ class EditRoot extends Component {
       salish: Yup.string()
         .max(150, 'cannot be more than 150 characters'),
       nicodemus: Yup.string()
-        .min(2, 'at least 2 characters are required')
+        .min(1, 'at least 1 character is required')
         .required('a root entry is required'),
       english: Yup.string()
         .min(1, 'at least 1 character is required')
@@ -101,7 +100,7 @@ class EditRoot extends Component {
             Fill in the fields below to edit the selected root.  When you save your edits, the old root entry will be set to 'inactive' status and will no longer display.  The edited root will display to users.  Please add an 'edit note' to briefly characterize the reason for the edit.  Edit notes do not display to users.
           </Message>
           {this.state.error && (
-            <div className="input-feedback">{this.state.error}</div>
+          <Message className="error">Unsuccessful: {this.state.error}</Message>
           )}
           <Segment stacked>
             <Formik
@@ -124,7 +123,7 @@ class EditRoot extends Component {
               <Form>
               <Input 
                   fluid 
-                  label={{ basic: true, color: 'blue', content: 'Affix ID' }}
+                  label={{ basic: true, color: 'blue', content: 'Root ID' }}
                   placeholder='The ID of the affix you are editing'
                   id='id'
                   type='text'
@@ -132,13 +131,11 @@ class EditRoot extends Component {
                   value={values.id}
                   onChange={handleChange}
 									onBlur={handleBlur}
-									// There are no errors for incorrect ID input because it loads pre-filled anyway
-                  className={ errors.type && touched.type ? 'text-input error' : 'text-input' }
                 />
                 <Input 
                   fluid 
-                  label={{ basic: true, color: 'blue', content: 'Root' }}
-                  placeholder='Root is required'
+                  label={{ color: 'blue', content: 'Root' }}
+                  placeholder='Root is required,'
                   id='root'
                   type='text'
                   value={values.root}
@@ -167,7 +164,7 @@ class EditRoot extends Component {
                 <Input 
                   fluid 
                   label={{ basic: true, color: 'blue', content: 'Salish' }}
-                  placeholder='Salish transcription is optional'
+                  placeholder='Salish transcription is optional.'
                   id='salish'
                   type='text'
                   value={values.salish}
@@ -181,7 +178,7 @@ class EditRoot extends Component {
                 <Input 
                   fluid 
                   label={{ color: 'blue', content: 'Nicodemus' }}
-                  placeholder='An entry for the root using the Nicodemus orthography is required'
+                  placeholder='An entry for the root using the Nicodemus orthography is required.'
                   id='nicodemus'
                   type='text'
                   value={values.nicodemus}
@@ -195,7 +192,7 @@ class EditRoot extends Component {
                 <Input 
                   fluid 
                   label={{ color: 'blue', content: 'English' }}
-                  placeholder='An English gloss for the root is required'
+                  placeholder='An English gloss for the root is required.'
                   id='english'
                   type='text'
                   value={values.english}
@@ -209,7 +206,7 @@ class EditRoot extends Component {
                 <Input 
                   fluid 
                   label={{ color: 'blue', content: 'Edit Note' }}
-                  placeholder='Please provide an editorial note.  Editorial notes do not display to users'
+                  placeholder='Please provide an editorial note.  Editorial notes do not display to users.'
                   id='editnote'
                   type='text'
                   value={values.editnote}
@@ -228,13 +225,7 @@ class EditRoot extends Component {
           />
         </Segment>
         <Segment>
-
-
-
-
-
 			<h3>Virtual Keyboard</h3>
-			<SimpleKeyboard / >
 			<SimpleKeyboard / >
       </Segment>
       </Grid.Column>

--- a/frontend/src/stems/AddStem.js
+++ b/frontend/src/stems/AddStem.js
@@ -73,11 +73,9 @@ class AddStem extends Component {
           <Message>
             Fill in the fields below to add a new stem to the list.  Any new stem must include an entry in the Nicodemus writing system, and an English translation.  Other fields are optional, and the layout of this list is based on Reichard 1938.  Links and pages show the affix in that publication.
           </Message>
-
           {this.state.error && (
-            <div className="input-feedback">{this.state.error}</div>
+          <Message className="error">Unsuccessful: {this.state.error}</Message>
           )}
-
           <Segment stacked>
           <Formik 
 							initialValues={{ category: '', reichard: '',
@@ -91,7 +89,7 @@ class AddStem extends Component {
     					<Form>
     						<Input 
                   fluid 
-                  label={{ basic: true, color: 'category', content: 'Category' }}
+                  label={{ basic: true, color: 'blue', content: 'Category' }}
     							placeholder='Including the stem category is optional.'
     							id='category'
                   type='text'
@@ -175,8 +173,8 @@ class AddStem extends Component {
                 )}
                 <Input 
                   fluid 
-                  label={{ basic: true, color: 'blue', content: 'Note' }}
-                  placeholder='A note is optional.'
+                  label={{ basic: true, color: 'blue', content: 'Stem Note' }}
+                  placeholder='A stem note is optional. It will display to users.'
                   id='note'
                   type='text'
                   value={values.note}
@@ -190,7 +188,7 @@ class AddStem extends Component {
                 <Input 
                   fluid 
                   label={{ basic: true, color: 'blue', content: 'Edit Note' }}
-                  placeholder='You can optionally include an editorial note about this entry.  Editorial notes do not display to users.'
+                  placeholder="You can optionally include an editorial note about this entry. This won't display to users."
                   id='editnote'
                   type='text'
                   value={values.editnote}

--- a/frontend/src/stems/EditStem.js
+++ b/frontend/src/stems/EditStem.js
@@ -69,7 +69,8 @@ class EditStem extends Component {
 	};
 
 	render() {
-
+		console.log("this.state.fields is")
+    console.log(this.state.fields)
 		const stemSchema = Yup.object().shape({
 			category: Yup.string()
 				.max(150, 'cannot exceed 150 characters'),
@@ -102,7 +103,7 @@ class EditStem extends Component {
             Fill in the fields below to edit the selected stem.  When you save your edits, the old stem entry will be set to 'inactive' status and will no longer display.  The edited stem will display to users.  Please add an 'edit note' to briefly characterize the reason for the edit.  Edit notes do not display to users.
           </Message>
           {this.state.error && (
-            <div className="input-feedback">{this.state.error}</div>
+          <Message className="error">Unsuccessful: {this.state.error}</Message>
           )}
           <Segment stacked>
             <Formik


### PR DESCRIPTION
Now the Add and Edit forms for affixes, stems, and roots have a red box around the error message. Got rid of some typos. Got rid of some unused code. AddAffix has an experimental label in two input fields, a work in progress.