### PR TITLE
jesttests for usersQ corresponds with sequelize testing, added 'update' role to backend 

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 COMPOSE_PROJECT_NAME=colrc-v2
 
 DB_NAME=colrc
-DB_USERNAME=jivens
-DB_PASSWORD=st33rpik3
+DB_USERNAME=amyfou
+DB_PASSWORD=Mat007teo!
 
 STATICELICITATIONSPATH=http://localhost:3500/elicitations/
 STATICMEDIAPATH=http://localhost:3500/texts/

--- a/frontend/src/users/UpdateRoles.js
+++ b/frontend/src/users/UpdateRoles.js
@@ -81,8 +81,9 @@ class UpdateRoles extends Component {
       .required('Required'),  
     });
     const roleOptions = [
-      {key: 'owner', text: 'owner', value: 'owner'},
       {key: 'admin', text: 'admin', value: 'admin'},
+      {key: 'owner', text: 'owner', value: 'owner'},
+      {key: 'update', text: 'update', value: 'update'},
       {key: 'view', text: 'view', value: 'view'} 
     ]
     return (     
@@ -95,8 +96,9 @@ class UpdateRoles extends Component {
             <Header as='h4' textAlign='center'>
               Select a new role for this user.
             </Header>
-            <div>'admin' = can update all information on this site, including user roles.</div>  
-            <div>'owner' = can update all information on this site, except user roles.</div>  
+            <div>'admin' = can update all information on this site, including user roles.</div> 
+            <div>'update' = can update all information on this site except user roles.</div>             
+            <div>'owner' = reserved to allow update access to individual areas.</div>  
             <div>'view' = cannot update information on this site.</div>
           </Message>
           {this.state.error && (


### PR DESCRIPTION
adminUser mutation requires 'owner' or 'admin', all other mutations are now set to allow 'owner', 'admin', or 'update' roles