### PR TITLE
Active status N is only visible to admins

### DIFF
--- a/backend/connectors/mysqlDB.js
+++ b/backend/connectors/mysqlDB.js
@@ -21,7 +21,7 @@ const sequelize = new Sequelize(
       collate: 'utf8mb4_unicode_ci',
       timestamps: true
     },
-    logging:false
+    // logging:false
   });
 
 sequelize
@@ -981,14 +981,22 @@ const affix_C = input => {
 }
 
 const affixes_C = input => {
+  let wherecond = {}
+  if (input.active) {
+    wherecond.active = input.active
+  }
   return Affix.findAll({
-    where: { }
+    where: wherecond
   })
 }
 
 const bibliographies_C = input => {
+  let wherecond = {}
+  if (input.active) {
+    wherecond.active = input.active
+  }
   return Bibliography.findAll({
-    where: { }
+    where: wherecond
   })
 }
 
@@ -1021,8 +1029,12 @@ const stem_C = input => {
 }
 
 const stems_C = input => {
+  let wherecond = {}
+  if (input.active) {
+    wherecond.active = input.active
+  }
   return Stem.findAll({
-    where: { }
+    where: wherecond
   })
 }
 
@@ -1049,8 +1061,12 @@ const spelling_C = input => {
   })
 }
 const spellings_C = input => {
+  let wherecond = {}
+  if (input.active) {
+    wherecond.active = input.active
+  }
   return Spelling.findAll({
-    where: { }
+    where: wherecond
   })
 }
 const consonants_C = input => {

--- a/backend/schema/schema.js
+++ b/backend/schema/schema.js
@@ -350,16 +350,16 @@ type Texttoaudiosetrelation {
     getUserFromToken_Q: User
     loginUser_Q(email:String!,password:String!): [LoginUser]
     users_Q: [User]
-    affixes_Q: [Affix]
+    affixes_Q(active: String, search: String): [Affix]
     affix_Q(id:ID!): Affix
-    roots_Q(active: String): [Root]
+    roots_Q(active: String, search: String): [Root]
     root_Q(id:ID!): Root
-    stems_Q: [Stem]
+    stems_Q(active: String, search: String): [Stem]
     stem_Q(id:ID!): Stem
-    bibliographies_Q: [Bibliography]
+    bibliographies_Q(active: String, search: String): [Bibliography]
     bibliography_Q(id:ID!): Bibliography
     spelling_Q(id:ID!): Spelling
-    spellings_Q: [Spelling]
+    spellings_Q(active: String, search: String): [Spelling]
     consonants_Q: [Consonant]
     vowels_Q: [Vowel]
     texts_Q: [Text]

--- a/frontend/src/affixes/AffixList.js
+++ b/frontend/src/affixes/AffixList.js
@@ -18,7 +18,8 @@ class AffixList extends Component {
 	  this.state = {
       //set up an empty array and a loading state for react-table
     	data: [],
-    	loading: true,
+      loading: true,
+      affixvars: {},
       //set up initial state for the checkboxes that allow show/hide columns.  Always default to show Nicodemus and English.  Always initially hide scary-looking orthographies like salish.
       typeSelected: false,
 		  salishSelected: false,
@@ -80,18 +81,19 @@ class AffixList extends Component {
         }
       // now we're going to get only active affixes if we are not admin, else 
       // we will get all the affixes
-      let affixvars = {}
+      // let affixvars = {}
       if (!this.state.fields.roles.includes("admin")){
-        affixvars.active = 'Y'
+        this.state.affixvars.active = 'Y'
       }
       const getAffixes = await this.props.client.query({
         query: getAffixesQuery,
-        variables: affixvars 
+        variables: this.state.affixvars 
       })
       this.setState({
         data: getAffixes.data.affixes_Q,
         loading: false
       })
+      
     } catch(error) {
       console.log(error)
     }
@@ -137,7 +139,7 @@ class AffixList extends Component {
           id: id
         },
       //after setting the flag, refetch the affixes from the db
-		  refetchQueries: [{ query: getAffixesQuery }]
+		  refetchQueries: [{ query: getAffixesQuery, variables: this.state.affixvars }]
       });
       //then send the user back to the affixlist display
       this.props.history.push('/affixes');

--- a/frontend/src/affixes/AffixList.js
+++ b/frontend/src/affixes/AffixList.js
@@ -78,6 +78,20 @@ class AffixList extends Component {
           console.log(this.state)
           console.log("and here's the role " + this.state.fields.roles)
         }
+      // now we're going to get only active affixes if we are not admin, else 
+      // we will get all the affixes
+      let affixvars = {}
+      if (!this.state.fields.roles.includes("admin")){
+        affixvars.active = 'Y'
+      }
+      const getAffixes = await this.props.client.query({
+        query: getAffixesQuery,
+        variables: affixvars 
+      })
+      this.setState({
+        data: getAffixes.data.affixes_Q,
+        loading: false
+      })
     } catch(error) {
       console.log(error)
     }
@@ -357,8 +371,8 @@ class AffixList extends Component {
     const dataOrError = this.state.error ?
       <div style={{ color: 'red' }}>Oops! Something went wrong!</div> :
       <ReactTable
-			  data={this.props.getAffixesQuery.affixes_Q}
-			  loading={this.props.getAffixesQuery.loading}
+			  data={this.state.data}
+			  loading={this.state.loading}
         columns={columns}
         defaultPageSize={10}
         className="-striped -highlight left"

--- a/frontend/src/queries/queries.js
+++ b/frontend/src/queries/queries.js
@@ -1,8 +1,8 @@
 import { gql } from 'apollo-boost';
 
 const getStemsQuery = gql`
-  {
-    stems_Q {
+  query($active: String){
+    stems_Q(active: $active) {
       id
       category
       reichard
@@ -43,8 +43,8 @@ const getUserFromToken = gql`
   }
 `;
 const getAffixesQuery = gql`
-  {
-    affixes_Q {
+  query($active: String){
+    affixes_Q(active: $active) {
       id
       type
       salish
@@ -97,8 +97,8 @@ const getRootsQuery = gql`
 
 
 const getBibliographiesQuery = gql`
-{
-  bibliographies_Q {
+query($active: String){
+  bibliographies_Q(active: $active) {
     id
     author
     year
@@ -148,8 +148,8 @@ const getSpellingQuery = gql`
 `;
 
 const getSpellingsQuery = gql`
-  {
-    spellings_Q {
+  query($active: String){
+    spellings_Q (active: $active){
       id
       reichard
       nicodemus

--- a/frontend/src/roots/RootsDictionary.js
+++ b/frontend/src/roots/RootsDictionary.js
@@ -48,40 +48,40 @@ class RootsDictionary extends Component {
   async componentDidMount() {
     try {
       const token = localStorage.getItem('TOKEN')
-      if (token) {
-        let userQuery = await this.props.client.query({
-          query: getUserFromToken,
-        })
-        const user = userQuery.data.getUserFromToken_Q
-        // set the state with user info based on token, and if the user has an 'admin' role, set 
-        // the state variable 'admin' to true.  Else, set it to false. 
-        await this.setState({
-          admin: user.roles.includes("admin") || user.roles.includes("owner") || user.roles.includes("update"),
-          fields: {
-            first: user.first,
-            last: user.last,
-            email: user.email,
-            username: user.username,
-            roles: user.roles
-          }
-        }) 
-        console.log("My user is " + user)
-        console.log(this.state)
-      } else {
-        await this.setState({
-          admin: false,
-          fields: {
-            first: "anonymous",
-            last: "anonymous",
-            email: "anonymous",
-            username: "anonymous",
-            roles: ["view"]
-          }
-        })
-        console.log(this.state)
-        console.log("and here's the role ")
-        console.log(this.state.fields.roles)
-      } 
+        if (token) {
+          let userQuery = await this.props.client.query({
+            query: getUserFromToken,
+          })
+          const user = userQuery.data.getUserFromToken_Q
+          // set the state with user info based on token, and if the user has an 'admin' role, set 
+          // the state variable 'admin' to true.  Else, set it to false. 
+          await this.setState({
+            admin: user.roles.includes("admin") || user.roles.includes("owner") || user.roles.includes("update"),
+            fields: {
+              first: user.first,
+              last: user.last,
+              email: user.email,
+              username: user.username,
+              roles: user.roles
+            }
+          }) 
+          console.log("My user is " + user)
+          console.log(this.state)
+        } else {
+          await this.setState({
+            admin: false,
+            fields: {
+              first: "anonymous",
+              last: "anonymous",
+              email: "anonymous",
+              username: "anonymous",
+              roles: ["view"]
+            }
+          })
+          console.log(this.state)
+          console.log("and here's the role ")
+          console.log(this.state.fields.roles)
+        } 
       // now we're going to get only active roots if we are not admin, else 
       // we will get all the roots
       let rootvars = {}
@@ -93,7 +93,8 @@ class RootsDictionary extends Component {
         variables: rootvars 
       })
       this.setState({
-        data: getRoots.data.roots_Q
+        data: getRoots.data.roots_Q,
+        loading: false
       })
     } catch(error) {
       console.log(error)
@@ -363,7 +364,7 @@ class RootsDictionary extends Component {
       <div style={{ color: 'red' }}>Oops! Something went wrong!</div> :
       <ReactTable
         data={this.state.data}
-        loading={this.props.getRootsQuery.loading}
+        loading={this.state.loading}
         columns={columns}
         filterable
         defaultPageSize={10}

--- a/frontend/src/spelling/SpellingPronunciationList.js
+++ b/frontend/src/spelling/SpellingPronunciationList.js
@@ -80,6 +80,20 @@ class SpellingPronunciationList extends Component {
           console.log(this.state)
           console.log("and here's the role " + this.state.fields.roles)
         }
+      // now we're going to get only active roots if we are not admin, else 
+      // we will get all the roots
+      let spellvars = {}
+      if (!this.state.fields.roles.includes("admin")){
+        spellvars.active = 'Y'
+      }
+      const getSpellings = await this.props.client.query({
+        query: getSpellingsQuery,
+        variables: spellvars 
+      })
+      this.setState({
+        data: getSpellings.data.spellings_Q,
+        loading: false
+      })
     } catch(error) {
       console.log(error)
     }
@@ -326,8 +340,8 @@ class SpellingPronunciationList extends Component {
     const dataOrError = this.state.error ?
       <div style={{ color: 'red' }}>Oops! Something went wrong!</div> :
       <ReactTable
-        data={this.props.getSpellingsQuery.spellings_Q}
-        loading={this.props.getSpellingsQuery.loading}
+        data={this.state.data}
+        loading={this.state.loading}
         columns={columns}
         filterable
         defaultPageSize={20}

--- a/frontend/src/stems/StemList.js
+++ b/frontend/src/stems/StemList.js
@@ -82,6 +82,21 @@ class StemList extends Component {
           console.log(this.state)
           console.log("and here's the role " + this.state.fields.roles)
         }
+      // now we're going to get only active stems if we are not admin, else 
+      // we will get all the stems
+      let stemvars = {}
+      if (!this.state.fields.roles.includes("admin")){
+        stemvars.active = 'Y'
+      }
+      const getStems = await this.props.client.query({
+        query: getStemsQuery,
+        variables: stemvars 
+      })
+      this.setState({
+        data: getStems.data.stems_Q,
+        loading: false
+      })
+
     } catch(error) {
       console.log(error)
     }
@@ -408,8 +423,8 @@ class StemList extends Component {
 		const dataOrError = this.state.error ?
      <div style={{ color: 'red' }}>Oops! Something went wrong!</div> :
 			<ReactTable
-				data={this.props.getStemsQuery.stems_Q}
-				loading={this.props.getStemsQuery.loading}
+				data={this.state.data}
+				loading={this.state.loading}
 				columns = {columns}
 				defaultPageSize = {10}
 				className = "-striped -highlight left"


### PR DESCRIPTION
Only users who are logged in as admin, update, or owner can see entries with an active status of 'N'. Also changed loading to say 'loading' instead of 'no rows found' in language tables. Bibliography is still missing these modifications, though.