### PR TITLE
DB now works properly with text image/audio files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.6"
 volumes:
   nginx_colrc:
-    external: true
+    #external: true
 services:
   hasura:
     image: hasura/graphql-engine:v1.3.3


### PR DESCRIPTION
Changed permissions and computed fields in Hasura, as well as renamed the files and database table entries so that we no longer get errors regarding URL length.

All text images/audio files are now showing up properly on my end, and this PR should nearly finish off issue #131 (save for working file uploads).