### PR TITLE
Address warnings in terminal on start

### DIFF
--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,6 +1,6 @@
 
 import React from "react";
-import { Message, Grid, Segment } from "semantic-ui-react"
+import { Message, Grid } from "semantic-ui-react"
 
 function Footer() {
     return (

--- a/frontend/src/pages/AddAffix.js
+++ b/frontend/src/pages/AddAffix.js
@@ -124,9 +124,7 @@ function AddAffix() {
                   },
                   {
                     label: 'No',
-                    // eslint-disable-next-line no-self-assign
-                    onClick: () => {values = values
-                                    setSubmitting(false)}
+                    onClick: () => setSubmitting(false)
                   }
                 ]
               });

--- a/frontend/src/pages/AddRoot.js
+++ b/frontend/src/pages/AddRoot.js
@@ -111,8 +111,7 @@ function AddRoot() {
                   },
                   {
                     label: 'No',
-                    onClick: () => {values = values
-                                    setSubmitting(false)}
+                    onClick: () => setSubmitting(false)
                   }
                 ]
               });

--- a/frontend/src/pages/AddRoot.js
+++ b/frontend/src/pages/AddRoot.js
@@ -1,13 +1,11 @@
 import React, { useState } from "react";
 import { Redirect, useHistory } from 'react-router-dom';
 import { insertRootMutation } from './../queries/queries'
-import { Button, Input, Dropdown, Label, Grid, Header, Message } from 'semantic-ui-react';
+import { Button, Input, Label, Grid, Header, Message } from 'semantic-ui-react';
 import * as Yup from 'yup';
 import { Formik, Form } from 'formik';
 import { useAuth } from "../context/auth";
-import { useQuery } from '@apollo/react-hooks'
 import { handleErrors, broadCastSuccess } from '../utils/messages';
-import { set } from "lodash";
 import { confirmAlert } from 'react-confirm-alert';
 import '../stylesheets/react-confirm-alert.css';
 

--- a/frontend/src/pages/AddStem.js
+++ b/frontend/src/pages/AddStem.js
@@ -1,13 +1,12 @@
 import React, { useState } from "react";
 import { Redirect, useHistory } from 'react-router-dom';
-import { insertStemMutation, getStemByIdQuery, getStemCategoriesQuery } from './../queries/queries'
+import { insertStemMutation, getStemCategoriesQuery } from './../queries/queries'
 import { Button, Input, Dropdown, Label, Grid, Header, Message } from 'semantic-ui-react';
 import * as Yup from 'yup';
 import { Formik, Form } from 'formik';
 import { useAuth } from "../context/auth";
 import { useQuery } from '@apollo/react-hooks'
 import { handleErrors, broadCastSuccess } from '../utils/messages';
-import { set } from "lodash";
 import { confirmAlert } from 'react-confirm-alert';
 import '../stylesheets/react-confirm-alert.css';
 

--- a/frontend/src/pages/AddStem.js
+++ b/frontend/src/pages/AddStem.js
@@ -77,7 +77,7 @@ function AddStem() {
 
   function dropDownOptions(options) {
       let res = []
-      options.map((item) => {
+      options.forEach((item) => {
           let h = {}
           h = { 
               key: item.id.toString(),

--- a/frontend/src/pages/AddStem.js
+++ b/frontend/src/pages/AddStem.js
@@ -128,8 +128,7 @@ function AddStem() {
                   },
                   {
                     label: 'No',
-                    onClick: () => {values = values
-                                    setSubmitting(false)}
+                    onClick: () => setSubmitting(false)
                   }
                 ]
               });

--- a/frontend/src/pages/AffixHistory.js
+++ b/frontend/src/pages/AffixHistory.js
@@ -1,21 +1,14 @@
 import React from 'react'
-import { Link, Redirect, useLocation, useHistory } from 'react-router-dom';
-import { intersectionWith, isEqual } from 'lodash';
-import { useTable, usePagination, useSortBy, useFilters, useGlobalFilter  } from 'react-table'
-import { DefaultColumnFilter, GlobalFilter, fuzzyTextFilterFn, SelectColumnFilter } from '../utils/Filters'
+import { useLocation } from 'react-router-dom';
 import { useAuth } from "../context/auth";
 import { getAffixHistoryByIdQuery } from './../queries/queries'
 import { useQuery } from '@apollo/react-hooks'
-import { sortReshape, filterReshape } from "./../utils/reshapers"
-import TableStyles from "./../stylesheets/table-styles"
-import { Icon, Button } from "semantic-ui-react";
 
 function AffixHistory() {
     const { client } = useAuth();
     const search = new URLSearchParams(useLocation().search)
     const id = search.get("id")
     console.log(id)
-    const history = useHistory()
   
     let { loading: affixHistoryLoading, error: affixHistoryError, data: affixHistoryData } = useQuery(getAffixHistoryByIdQuery, 
         {client: client, variables: {"table_name": "affixes", "row_data": {"id": parseInt(id)}} }) 

--- a/frontend/src/pages/AffixTable.js
+++ b/frontend/src/pages/AffixTable.js
@@ -503,7 +503,7 @@ function AffixTable(props) {
         })
       }
     }, 1000)
-  }, [])
+  }, [history, setAuthTokens])
 
   let columns = {}
   if(user && intersectionWith(["manager", "update"], user.roles, isEqual).length >= 1) {

--- a/frontend/src/pages/AudioTable.js
+++ b/frontend/src/pages/AudioTable.js
@@ -32,7 +32,6 @@ function Table({
     }),
     []
   )
-  const { user } = useAuth();
   const defaultColumn = React.useMemo(
     () => ({
       Filter: DefaultColumnFilter,       // Let's set up our default Filter UI

--- a/frontend/src/pages/BibliographyTable.js
+++ b/frontend/src/pages/BibliographyTable.js
@@ -1,13 +1,10 @@
 import React from 'react'
-import { Link } from 'react-router-dom';
-import { intersectionWith, isEqual } from 'lodash';
 import { useTable, usePagination, useSortBy, useFilters, useGlobalFilter  } from 'react-table'
 import { DefaultColumnFilter, GlobalFilter, fuzzyTextFilterFn, NarrowColumnFilter } from '../utils/Filters'
 import { useAuth } from "../context/auth";
 import { getBibliographyQuery } from '../queries/queries'
 import { sortReshape, filterReshape } from "../utils/reshapers"
 import TableStyles from "../stylesheets/table-styles"
-import { Icon, Button } from "semantic-ui-react";
 
 function Table({
   columns,
@@ -17,8 +14,6 @@ function Table({
   pageCount: controlledPageCount,
   globalSearch
 }) {
-
-  const { user } = useAuth();
 
   //console.log("Inside table, I have select values: ", selectValues)
   //console.log("Inside table, I have a globalSearch ", globalSearch)

--- a/frontend/src/pages/BrowseRoot.js
+++ b/frontend/src/pages/BrowseRoot.js
@@ -529,7 +529,7 @@ function BrowseRootTable(props) {
         })
       }
     }, 1000)
-  }, [])
+  }, [history, location, root, setAuthTokens])
 
   let columns = {}
   if(user && intersectionWith(["manager", "update"], user.roles, isEqual).length >= 1) {

--- a/frontend/src/pages/DeleteAffix.js
+++ b/frontend/src/pages/DeleteAffix.js
@@ -114,8 +114,7 @@ function DeleteAffix() {
                   },
                   {
                     label: 'No',
-                    onClick: () => {values = values
-                        setSubmitting(false)}
+                    onClick: () => setSubmitting(false)
                   }
                 ]
               });

--- a/frontend/src/pages/DeleteAffix.js
+++ b/frontend/src/pages/DeleteAffix.js
@@ -115,7 +115,7 @@ function DeleteAffix() {
                   {
                     label: 'No',
                     onClick: () => {values = values
-                                    setSubmitting(false)}
+                        setSubmitting(false)}
                   }
                 ]
               });
@@ -212,7 +212,7 @@ function DeleteAffix() {
                     </Grid.Column>
                 </Grid.Row>
                 <Grid.Row>
-                    <Grid.Column width={2} textAlign="right"><Label basic pointing="right" basic color="blue">Link Text</Label></Grid.Column>
+                    <Grid.Column width={2} textAlign="right"><Label pointing="right" basic color="blue">Link Text</Label></Grid.Column>
                     <Grid.Column width={10}>
                         <Input
                             disabled
@@ -230,10 +230,9 @@ function DeleteAffix() {
                     </Grid.Column>
                 </Grid.Row>
                 <Grid.Row>
-                    <Grid.Column width={2} textAlign="right"><Label pointing="right" basic color="blue">Note</Label></Grid.Column>
+                    <Grid.Column width={2} textAlign="right"><Label pointing="right" color="blue">Note</Label></Grid.Column>
                     <Grid.Column width={10}>
                         <Input
-                            disabled
                             fluid
                             style={{ paddingBottom: '5px' }}
                             id="editnote"

--- a/frontend/src/pages/DeleteRoot.js
+++ b/frontend/src/pages/DeleteRoot.js
@@ -109,8 +109,7 @@ function DeleteAffix() {
                   },
                   {
                     label: 'No',
-                    onClick: () => {values = values
-                                    setSubmitting(false)}
+                    onClick: () => setSubmitting(false)
                   }
                 ]
               });

--- a/frontend/src/pages/DeleteRoot.js
+++ b/frontend/src/pages/DeleteRoot.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Redirect, useLocation, useHistory } from 'react-router-dom';
 import { getRootByIdQuery, deleteRootMutation } from '../queries/queries'
-import { Button, Input, Dropdown, Label, Grid, Header, Message } from 'semantic-ui-react';
+import { Button, Input, Label, Grid, Header, Message } from 'semantic-ui-react';
 import { Formik, Form } from 'formik';
 import * as Yup from 'yup';
 import { useAuth } from "../context/auth";

--- a/frontend/src/pages/DeleteRoot.js
+++ b/frontend/src/pages/DeleteRoot.js
@@ -318,10 +318,9 @@ function DeleteAffix() {
                     </Grid.Column>
                 </Grid.Row>
                 <Grid.Row>
-                    <Grid.Column width={2} textAlign="right"><Label pointing="right" basic color="blue">Edit Note</Label></Grid.Column>
+                    <Grid.Column width={2} textAlign="right"><Label pointing="right" color="blue">Edit Note</Label></Grid.Column>
                     <Grid.Column width={10}>
                         <Input
-                            disabled
                             fluid
                             style={{ paddingBottom: '5px' }}
                             id="editnote"

--- a/frontend/src/pages/DeleteStem.js
+++ b/frontend/src/pages/DeleteStem.js
@@ -28,10 +28,10 @@ function DeleteStem() {
     let { loading: stemLoading, error: stemError, data: stemData } = useQuery(getStemByIdQuery, {client: client, variables: {id: id} }) 
     let { loading: categoryLoading, error: categoryError, data: categoryData } = useQuery(getStemCategoriesQuery, {client: client }) 
         
-    if (categoryLoading) {
+    if (categoryLoading || stemLoading) {
         return <div>loading...</div>
     }
-    if (categoryError) {
+    if (categoryError || stemError) {
         return <div>Something went wrong</div>
     }
     

--- a/frontend/src/pages/DeleteStem.js
+++ b/frontend/src/pages/DeleteStem.js
@@ -241,7 +241,6 @@ function DeleteStem() {
                     <Grid.Column width={10}>
                         <Input
                             fluid
-                            disabled
                             style={{ paddingBottom: '5px' }}
                             id="editnote"
                             placeholder="An edit note is required"

--- a/frontend/src/pages/DeleteStem.js
+++ b/frontend/src/pages/DeleteStem.js
@@ -114,9 +114,7 @@ function DeleteStem() {
                   },
                   {
                     label: 'No',
-                    // eslint-disable-next-line no-self-assign
-                    onClick: () => {values = values
-                                    setSubmitting(false)}
+                    onClick: () => setSubmitting(false)
                   }
                 ]
               });

--- a/frontend/src/pages/DeleteStem.js
+++ b/frontend/src/pages/DeleteStem.js
@@ -63,7 +63,7 @@ function DeleteStem() {
     
     function dropDownOptions(options) {
         let res = []
-        options.map((item) => {
+        options.forEach((item) => {
             let h = {}
             h = { 
                 key: item.id.toString(),

--- a/frontend/src/pages/EditAffix.js
+++ b/frontend/src/pages/EditAffix.js
@@ -129,9 +129,7 @@ function EditAffix() {
                   },
                   {
                     label: 'No',
-                    // eslint-disable-next-line no-self-assign
-                    onClick: () => {values = values
-                                    setSubmitting(false)}
+                    onClick: () => setSubmitting(false)
                   }
                 ]
               });

--- a/frontend/src/pages/EditRoot.js
+++ b/frontend/src/pages/EditRoot.js
@@ -137,8 +137,7 @@ function EditRoot() {
                   },
                   {
                     label: 'No',
-                    onClick: () => {values = values
-                                    setSubmitting(false)}
+                    onClick: () => setSubmitting(false)
                   }
                 ]
               });

--- a/frontend/src/pages/EditRoot.js
+++ b/frontend/src/pages/EditRoot.js
@@ -1,13 +1,12 @@
 import React, { useState } from "react";
 import { Redirect, useLocation, useHistory } from 'react-router-dom';
 import { getRootByIdQuery, updateRootMutation } from '../queries/queries'
-import { Button, Input, Dropdown, Label, Grid, Header, Message } from 'semantic-ui-react';
+import { Button, Input, Label, Grid, Header, Message } from 'semantic-ui-react';
 import * as Yup from 'yup';
 import { Formik, Form } from 'formik';
 import { useAuth } from "../context/auth";
 import { useQuery } from '@apollo/react-hooks'
 import { handleErrors, broadCastSuccess } from '../utils/messages';
-import { set } from "lodash";
 import { confirmAlert } from 'react-confirm-alert';
 import '../stylesheets/react-confirm-alert.css';
 

--- a/frontend/src/pages/EditStem.js
+++ b/frontend/src/pages/EditStem.js
@@ -33,10 +33,10 @@ function EditStem() {
     let { loading: stemLoading, error: stemError, data: stemData } = useQuery(getStemByIdQuery, {client: client, variables: {id: id} }) 
     let { loading: categoryLoading, error: categoryError, data: categoryData } = useQuery(getStemCategoriesQuery, {client: client }) 
         
-    if (categoryLoading) {
+    if (categoryLoading || stemLoading) {
         return <div>loading...</div>
     }
-    if (categoryError) {
+    if (categoryError || stemError) {
         return <div>Something went wrong</div>
     }
     

--- a/frontend/src/pages/EditStem.js
+++ b/frontend/src/pages/EditStem.js
@@ -76,7 +76,7 @@ function EditStem() {
     
     function dropDownOptions(options) {
         let res = []
-        options.map((item) => {
+        options.forEach((item) => {
             let h = {}
             h = { 
                 key: item.id.toString(),

--- a/frontend/src/pages/EditStem.js
+++ b/frontend/src/pages/EditStem.js
@@ -127,9 +127,7 @@ function EditStem() {
                   },
                   {
                     label: 'No',
-                    // eslint-disable-next-line no-self-assign
-                    onClick: () => {values = values
-                                    setSubmitting(false)}
+                    onClick: () => setSubmitting(false)
                   }
                 ]
               });

--- a/frontend/src/pages/ElicitationsTable.js
+++ b/frontend/src/pages/ElicitationsTable.js
@@ -32,7 +32,6 @@ function Table({
     }),
     []
   )
-  const { user } = useAuth();
   const defaultColumn = React.useMemo(
     () => ({
       Filter: DefaultColumnFilter,       // Let's set up our default Filter UI

--- a/frontend/src/pages/ExactRoot.js
+++ b/frontend/src/pages/ExactRoot.js
@@ -18,8 +18,7 @@ function Table({
 {
     let happy = new URLSearchParams(useLocation().search)
     let root = happy.get('root')
-    console.log('the root is ', root)    
-    const { user } = useAuth();
+    console.log('the root is ', root)
 
 
     const {

--- a/frontend/src/pages/Log.js
+++ b/frontend/src/pages/Log.js
@@ -1,22 +1,8 @@
 import React from 'react'
-import { Link, Redirect, useLocation, useHistory } from 'react-router-dom';
-import { intersectionWith, isEqual } from 'lodash';
-import { useTable, usePagination, useSortBy, useFilters, useGlobalFilter  } from 'react-table'
-import { DefaultColumnFilter, GlobalFilter, fuzzyTextFilterFn, SelectColumnFilter } from '../utils/Filters'
-import { useAuth } from "../context/auth";
-import { getLogQuery } from './../queries/queries'
-import { useQuery } from '@apollo/react-hooks'
 import LogTable from './LogTable'
-import { sortReshape, filterReshape } from "./../utils/reshapers"
-import TableStyles from "./../stylesheets/table-styles"
-import { Icon, Button } from "semantic-ui-react";
 
 function Log() {
-    const { client } = useAuth();
-    const history = useHistory()
-
     return <LogTable/>
-
 }
 
 

--- a/frontend/src/pages/LogTable.js
+++ b/frontend/src/pages/LogTable.js
@@ -104,7 +104,7 @@ function Table({
         columns.filter(column => !column.show).map(column => column.id)
       );
     },
-    [columns]
+    [columns, setHiddenColumns]
   );
 
   // Render the UI for your table

--- a/frontend/src/pages/LogTable.js
+++ b/frontend/src/pages/LogTable.js
@@ -1,13 +1,11 @@
 import React from 'react'
-import { Link } from 'react-router-dom';
 import { intersectionWith, isEqual } from 'lodash';
 import { useTable, usePagination, useSortBy, useFilters, useGlobalFilter  } from 'react-table'
-import { DefaultColumnFilter, GlobalFilter, fuzzyTextFilterFn, SelectColumnFilter } from '../utils/Filters'
+import { DefaultColumnFilter, GlobalFilter, fuzzyTextFilterFn } from '../utils/Filters'
 import { useAuth } from "../context/auth";
 import { getLogQuery } from './../queries/queries'
 import { sortReshape, filterReshape } from "./../utils/reshapers"
 import TableStyles from "./../stylesheets/table-styles"
-import { Icon, Button } from "semantic-ui-react";
 
 function Table({
   columns,
@@ -56,7 +54,6 @@ function Table({
     page,
     state,
     allColumns,
-    getToggleHideAllColumnsProps,
     setHiddenColumns,
     visibleColumns,
     preGlobalFilteredRows,

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -13,7 +13,6 @@ import { handleErrors } from '../utils/messages';
 
 
 function Login(props) {
-  const abortController = new AbortController();
   const [isLoggedIn, setLoggedIn] = useState(false);
   const [isError, setIsError] = useState(false);
   const { authClient, setAuthTokens } = useAuth();

--- a/frontend/src/pages/Metadata.js
+++ b/frontend/src/pages/Metadata.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useTable } from 'react-table'
-import { useLocation, } from 'react-router-dom';
 import { useAuth } from "../context/auth";
 import TableStyles from "./../stylesheets/table-styles"
 import { Message } from "semantic-ui-react";
@@ -11,13 +10,12 @@ function Table({
   columns,
   data,
   fetchData,
-  loading,
+  // loading,
 }) 
 {
     //let happy = new URLSearchParams(useLocation().search)
     //let root = happy.get('root')
     //console.log('the root is ', root)    
-    const { user } = useAuth();
 
     const {
             getTableProps,

--- a/frontend/src/pages/RootHistory.js
+++ b/frontend/src/pages/RootHistory.js
@@ -1,16 +1,14 @@
 import React from 'react'
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useAuth } from "../context/auth";
 import { getRootHistoryByIdQuery } from '../queries/queries'
 import { useQuery } from '@apollo/react-hooks'
-import { Grid } from 'semantic-ui-react'
 
 function RootHistory(props) {
     const { client } = useAuth();
     const search = new URLSearchParams(useLocation().search)
     const id = search.get("id")
     console.log(id)
-    const history = useHistory()
   
     let { loading, error, data } = useQuery(getRootHistoryByIdQuery, 
         {client: client, variables: {"table_name": "roots", "row_data": {"id": parseInt(id)}} }) 
@@ -23,7 +21,7 @@ function RootHistory(props) {
     }
     console.log(data.audit_logged_actions)
 
-    let headings = JSON.stringify(data.audit_logged_actions)
+    // let headings = JSON.stringify(data.audit_logged_actions)
 
     function MakeRows(){
  

--- a/frontend/src/pages/RootTable.js
+++ b/frontend/src/pages/RootTable.js
@@ -596,7 +596,7 @@ function RootTable(props) {
         })
       }
     }, 1000)
-  }, [])
+  }, [history, setAuthTokens])
 
   let columns = {}
   if(user && intersectionWith(["manager", "update"], user.roles, isEqual).length >= 1) {

--- a/frontend/src/pages/Roots.js
+++ b/frontend/src/pages/Roots.js
@@ -1,11 +1,9 @@
 import React from "react"
-import { useAuth } from "../context/auth"
 import { Grid, Container } from 'semantic-ui-react'
 import RootsAccordion from "./accordions/RootsAccordion";
 import RootTable from "./RootTable"
 
 function Roots(props) {
-  const { client } = useAuth()
 
   return (
     <React.Fragment>

--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from "react";
 import Keyboard from "react-simple-keyboard";
-import { useLocation, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Grid, Header, Segment, Message, Input } from 'semantic-ui-react';
 import "react-simple-keyboard/build/css/index.css";
 

--- a/frontend/src/pages/Signup.js
+++ b/frontend/src/pages/Signup.js
@@ -34,7 +34,7 @@ let signupSchema = Yup.object().shape({
 
 function Signup(props) {
   const [hasRegistered, setHasRegistered] = useState(false);
-  const [isError, setIsError] = useState(false);
+  // const [isError, setIsError] = useState(false);
   const history = useHistory();
   const { client, authClient, setAuthTokens } = useAuth();
 
@@ -78,7 +78,7 @@ function Signup(props) {
       })
       if (!tokenQuery.data.loginUser_Q) {
         handleErrors(`Username or Password is incorrect`) 
-        setIsError(true)
+        // setIsError(true)
       }
       else {
         const token = tokenQuery.data.loginUser_Q[0].password

--- a/frontend/src/pages/Spelling.js
+++ b/frontend/src/pages/Spelling.js
@@ -2,7 +2,7 @@ import React from "react";
 import SpellingTable from "./SpellingList";
 import ConsonantChart from "./ConsonantChart";
 import VowelChart from "./VowelChart";
-import { Grid, Segment, Header, Message } from 'semantic-ui-react'
+import { Grid, Segment, Header } from 'semantic-ui-react'
 import SpellingAccordion from "./accordions/SpellingAccordion";
 
 function Spelling(props) {

--- a/frontend/src/pages/StemTable.js
+++ b/frontend/src/pages/StemTable.js
@@ -499,7 +499,7 @@ function StemTable(props) {
         })
       }
     }, 1000)
-  }, [])
+  }, [history, setAuthTokens])
 
   let columns = {}
   if(user && intersectionWith(["manager", "update"], user.roles, isEqual).length >= 1) {

--- a/frontend/src/pages/TestUpload.js
+++ b/frontend/src/pages/TestUpload.js
@@ -1,6 +1,4 @@
 import React from "react";
-import Uploady from "@rpldy/uploady";
-import UploadButton from "@rpldy/upload-button"
 import { Grid } from  "semantic-ui-react";
 
 

--- a/frontend/src/pages/TextTable.js
+++ b/frontend/src/pages/TextTable.js
@@ -18,9 +18,9 @@ function Table({
   renderRowSubComponent
 }) {
 
-  const { user } = useAuth();
-  //console.log("Inside table, I have select values: ", selectValues)
-  //console.log("my user is: ", user)
+  // const { user } = useAuth();
+  // console.log("Inside table, I have select values: ", selectValues)
+  // console.log("my user is: ", user)
 
   const filterTypes = React.useMemo(
     () => ({

--- a/frontend/src/pages/TextTable.js
+++ b/frontend/src/pages/TextTable.js
@@ -112,7 +112,7 @@ function Table({
         columns.filter(column => !column.show).map(column => column.id)
       );
     },
-    [columns]
+    [columns, setHiddenColumns]
   );
 
   // Render the UI for your table

--- a/frontend/src/pages/accordions/RootsAccordion.js
+++ b/frontend/src/pages/accordions/RootsAccordion.js
@@ -52,7 +52,7 @@ export default function RootsAccordion() {
                   <li>‿ — Ligature (following proclitic set of intransitive pronouns)</li>
                   <li>† — Intransitive entry</li>
                   <li>‡ — Transitive entry</li>
-                  <li>// — Complex entry</li>
+                  <li>{"//"} — Complex entry</li>
                   <li>§ — Compound entry</li>
                   <li>[ ] — Brackets for editorial emendations and special notes</li>
                   <li>adj — Adjective</li>

--- a/frontend/src/utils/AudioPlayer.js
+++ b/frontend/src/utils/AudioPlayer.js
@@ -22,15 +22,15 @@ class AudioPlayer extends Component {
    }
 
   render() {
-    const hasTitle = this.props.title.length > 0;
-    const hasSpeaker = this.props.speaker ? true : false;
-    const hasLanguage = this.props.language ? true: false;
-    const conditionalTitle = hasTitle ? this.props.title : '';
-    const title = hasSpeaker && hasTitle
-      ? <p>{this.props.title}, spoken by {this.props.speaker}</p>
-      : (hasTitle
-        ? <p>{this.props.title}</p>
-        : '')
+    // const hasTitle = this.props.title.length > 0;
+    // const hasSpeaker = this.props.speaker ? true : false;
+    // const hasLanguage = this.props.language ? true: false;
+    // const conditionalTitle = hasTitle ? this.props.title : '';
+    // const title = hasSpeaker && hasTitle
+    //   ? <p>{this.props.title}, spoken by {this.props.speaker}</p>
+    //   : (hasTitle
+    //     ? <p>{this.props.title}</p>
+    //     : '')
 
     return (
       <div key={this.props.id}>

--- a/frontend/src/utils/ElicitationsPlayer.js
+++ b/frontend/src/utils/ElicitationsPlayer.js
@@ -22,15 +22,15 @@ class ElicitationsPlayer extends Component {
    }
 
   render() {
-    const hasTitle = this.props.title.length > 0;
-    const hasSpeaker = this.props.speaker ? true : false;
-    const hasLanguage = this.props.language ? true: false;
-    const conditionalTitle = hasTitle ? this.props.title : '';
-    const title = hasSpeaker && hasTitle
-      ? <p>{this.props.title}, spoken by {this.props.speaker}</p>
-      : (hasTitle
-        ? <p>{this.props.title}</p>
-        : '')
+    // const hasTitle = this.props.title.length > 0;
+    // const hasSpeaker = this.props.speaker ? true : false;
+    // const hasLanguage = this.props.language ? true: false;
+    // const conditionalTitle = hasTitle ? this.props.title : '';
+    // const title = hasSpeaker && hasTitle
+    //   ? <p>{this.props.title}, spoken by {this.props.speaker}</p>
+    //   : (hasTitle
+    //     ? <p>{this.props.title}</p>
+    //     : '')
 
     return (
       <div key={this.props.id}>

--- a/frontend/src/utils/Filters.js
+++ b/frontend/src/utils/Filters.js
@@ -291,7 +291,7 @@ export function SelectOrthographyFilter({
       options.add("N")
     })
     return [...options.values()]
-  }, [id, preFilteredRows])
+  }, [preFilteredRows])
   // Render a multi-select box
   return (
     <select

--- a/frontend/src/utils/messages.js
+++ b/frontend/src/utils/messages.js
@@ -12,7 +12,7 @@ export function handleErrors(error, action) {
 
     const { graphQLErrors, networkError } = error
     if (graphQLErrors)
-    graphQLErrors.map(({ message, locations, path }) => {
+    graphQLErrors.forEach(({ message, locations, path }) => {
         if (message.includes('JWTExpired')) {
             toast.error(`Whoops!  You have an old login.  Logging you out now`,)
             if (action && action.logout) {


### PR DESCRIPTION
Removes most of the warnings on startup, however some still remain due to infinite rendering if certain methods are added to the `React.useCallback()`/`React.useEffect()` dependency arrays. Thus, while somewhat fixing #69, there is more work to be done...

In particular, self-assigned variables and unused variables/imports were removed, as well as instances where `.map()` is being called instead of `.forEach()` when no returns are expected. Additionally, editnote behavior was fixed, which was needed in order to test some changes for the issue.

I manually tested each page on Firefox as it was edited, and no bugs seemed to arise on my end.