### PR TITLE
Changed static files for nginx from internal volumes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # package-lock.json
-nginx/file_data
+misc/file_data
 node_modules
 dist
 *.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       - "443:443"
     volumes:
       # FIXME: add files and colrc frontend
-      - nginx_colrc:/var/www/colrc:rw
+      - ./misc/file_data:/var/www/colrc:rw
     networks:
       vpcbr:
         ipv4_address: 10.5.0.6
@@ -133,7 +133,7 @@ services:
     ports:
       - "8081:8081"
     volumes:
-      - nginx_colrc:/var/www/colrc:rw
+      - ./misc/file_data:/var/www/colrc:rw
     networks:
       vpcbr:
         ipv4_address: 10.5.0.7


### PR DESCRIPTION
Changed static files for nginx from internal volumes to volumes mapped to a local drive.
It will now be necessary for each person to curl the dropbox files to get them from the dropbox.
