### PR TITLE
Created program to sync Dropbox folder with local filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # package-lock.json
-misc/file_data
 node_modules
 dist
 *.log

--- a/README.md
+++ b/README.md
@@ -54,11 +54,17 @@ Here are the steps we recommend to start (as of 7/14/2021). If this is your firs
     
     `docker-compose build`
 
-4. Once the build has finished, download our image/audio files from Dropbox. As files are updated in our Dropbox folder, you can run this script while the development environment is down to keep your local filesystem up to date.
+4. Once the build has finished, download our image/audio files from Dropbox. As files are updated in our Dropbox folder, you can run the script below while the development environment is down to keep your local filesystem up to date.
   
+      If you do not have the [`requests`](https://docs.python-requests.org/en/master/user/install/#install) library, you will need to install it:
+      
+      `pip3 install requests` or `python3 -m pip install requests`
+      
+      If you already have it or you have finished installing `requests`, you can run the script using the command below:
+
       `python3 misc/dropbox-sync.py`
 
-5. Then you may start our development environment as a background process:
+5. Then you may finally start our development environment as a background process!
 
     `docker-compose up -d`
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Here are the steps we recommend to start (as of 7/14/2021). If this is your firs
 
 - [`docker`](https://docs.docker.com/install/)
 - [`docker-compose`](https://docs.docker.com/compose/install/)
+- [`git`](https://git-scm.com/downloads)
+- [`python3`](https://www.python.org/downloads/)
 - If you are running Windows, you'll need to use [`WSL`](https://docs.microsoft.com/en-us/windows/wsl/install-win10) with [`Debian`](https://wiki.debian.org/InstallingDebianOn/Microsoft/Windows/SubsystemForLinux) 
 - You will need sudo/root access on your system at the command line.
 - We recommend using [`VSCode`](https://code.visualstudio.com/) as your code editor for this project.
@@ -52,23 +54,15 @@ Here are the steps we recommend to start (as of 7/14/2021). If this is your firs
     
     `docker-compose build`
 
-4. Once the build has finished, start our development environment as a background process:
+4. Once the build has finished, download our image/audio files from Dropbox. As files are updated in our Dropbox folder, you can run this script while the development environment is down to keep your local filesystem up to date.
+  
+      `python3 misc/dropbox-sync.py`
+
+5. Then you may start our development environment as a background process:
 
     `docker-compose up -d`
 
-    Note that it may take a tiny bit after the command has completed in order for the environment to be fully up and running. To test this, go to http://localhost:3000 and check to make sure the site is working before proceeding to the next step!
-
-  5. Once the project is up, change to the file data directory and download our image/audio files from Dropbox:
-  
-      `cd misc/file_data && sudo curl -Lo files.zip https://www.dropbox.com/sh/jtd0hw3r97rj48q/AADPJFTY0KvJnz83zK97vZh0a?dl=0`
-  
-  6. When the files are finished downloading, unzip and remove the resulting `.zip` file:
-
-      `unzip files.zip -x / && rm -f files.zip`
-  
-  7. Finally, with the files unzipped, change the file/directory permissions so that they are executable for all users: 
-      
-      `sudo chmod -R +x *`
+    Note that it may take a tiny bit after the command has completed in order for the environment to be fully up and running. To see if it is ready to go, check http://localhost:3000 and make sure you can see the website before proceeding!
 
 ### Subsequent Installations
 If this is NOT your first install and there have been changes to the database or static file structures in the GitHub repository, you will need to do the following:
@@ -83,7 +77,7 @@ If this is NOT your first install and there have been changes to the database or
 
 3. At the command line, remove any previous database/file data if it exists:
 
-   `sudo rm -rf db_data && sudo rm -rf file_data`
+   `sudo rm -rf misc/db_data misc/file_data`
   
 4. Follow the first installation steps starting from [step 3](#step-3).
 

--- a/misc/.gitignore
+++ b/misc/.gitignore
@@ -1,3 +1,4 @@
 db_data
+dropbox-sync.log
 file_data
 cursor

--- a/misc/.gitignore
+++ b/misc/.gitignore
@@ -1,1 +1,3 @@
 db_data
+file_data
+cursor

--- a/misc/.gitignore
+++ b/misc/.gitignore
@@ -1,4 +1,2 @@
 db_data
-dropbox-sync.log
 file_data
-cursor

--- a/misc/dropbox-sync.py
+++ b/misc/dropbox-sync.py
@@ -1,0 +1,137 @@
+import click
+import json
+import os
+import requests
+import shutil
+import zipfile
+
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+FILE_DIR = f'{BASE_DIR}/file_data'
+ZIP_FILE= f'{BASE_DIR}/files.zip'
+CURSOR_FILE = f'{BASE_DIR}/cursor'
+
+DROPBOX_FILE_DIR='/colrc-v2-files'
+DROPBOX_ACCESS_TOKEN='H66L2R8JfX8AAAAAAAAAASyxUvZolCy956ASqQZjEPhFHXDbfa5zbk1pmNdsxYSA'
+
+def download_folder(folder, dl_location, rename=False, progress=False):
+    headers = {
+        'Authorization': f'Bearer {DROPBOX_ACCESS_TOKEN}',
+        'Dropbox-API-Arg': f'{{"path": "{folder}"}}'
+    }
+    
+    response = requests.post('https://content.dropboxapi.com/2/files/download_zip', headers=headers, stream=True)
+    
+    print('\nDownloading zip file from Dropbox...')
+    with open(ZIP_FILE, 'wb') as f:
+        megabytes_written = 0
+        for chunk in response.iter_content(chunk_size=1024):
+            f.write(chunk)
+            megabytes_written += 1/1024
+            if progress:
+                print(f'\r{megabytes_written:.0f}MB downloaded...', end='', flush=True)
+    
+    print('\nExtracting zip file...')
+    with zipfile.ZipFile(ZIP_FILE, 'r') as z:
+        z.filename = 'file_data'
+        z.extractall(dl_location)
+
+    if rename:
+        print('Renaming folder...')
+        os.rename(f'{BASE_DIR}/{DROPBOX_FILE_DIR}', FILE_DIR)
+
+    print('Removing zip file...')
+    os.remove(ZIP_FILE)
+
+    print('Changing file permissions...')
+    for root, dirs, files in os.walk(FILE_DIR):
+        for d in dirs:
+            os.chmod(os.path.join(root, d), 0o777)
+        for f in files:
+            os.chmod(os.path.join(root, f), 0o777)
+
+def download_file(file, dl_location):
+    headers = {
+        'Authorization': f'Bearer {DROPBOX_ACCESS_TOKEN}',
+        'Dropbox-API-Arg': f'{{"path": "{file}"}}'
+    }
+    
+    response = requests.post('https://content.dropboxapi.com/2/files/download', headers=headers)
+    
+    with open(dl_location, 'wb') as f:
+        f.write(response.content)
+            
+def save_cursor():
+    headers = {
+    'Authorization': f'Bearer {DROPBOX_ACCESS_TOKEN}',
+    'Content-Type': 'application/json'
+    }
+    data = f'{{"path": "{DROPBOX_FILE_DIR}", "recursive": true, "include_deleted": true, "include_non_downloadable_files": false}}'
+
+    response = requests.post('https://api.dropboxapi.com/2/files/list_folder/get_latest_cursor', headers=headers, data=data)
+    cursor = json.loads(response.text)['cursor']
+    
+    print('\nSaving cursor...')
+    with open(CURSOR_FILE, 'w') as f:
+        f.write(cursor)
+
+def update(cursor):
+    headers = {
+    'Authorization': f'Bearer {DROPBOX_ACCESS_TOKEN}',
+    'Content-Type': 'application/json'
+    }
+    data = f'{{"cursor": "{cursor}"}}'
+
+    updated_files = json.loads(requests.post('https://api.dropboxapi.com/2/files/list_folder/continue', headers=headers, data=data).content)
+    
+    print('\nUpdating files:')
+    for entry in updated_files['entries']:
+        local_path = f'{FILE_DIR}{entry["path_display"].replace(DROPBOX_FILE_DIR, "")}'
+        
+        if entry['.tag'] == 'deleted':
+            try:
+                if os.path.isdir(local_path):
+                    shutil.rmtree(local_path)
+                else:
+                    os.remove(local_path)
+                print(f'DEL {entry["name"]}')
+            except:
+                print(f'ERR DEL {entry["name"]}')
+        
+        elif entry['.tag'] == 'file':
+            try:
+                download_file(entry['path_display'], local_path)
+                print(f'ADD {entry["name"]}')
+            except:
+                print(f'ERR ADD {entry["name"]}')
+        
+        elif entry['.tag'] == 'folder':
+            try:
+                download_folder(entry['path_display'], local_path.replace(entry['name'], ''))
+                print(f'ADD {entry["name"]}')
+            except:
+                print(f'ERR ADD {entry["name"]}')
+
+def main():
+    if os.path.isdir(FILE_DIR):
+        if os.path.isfile(CURSOR_FILE):
+            print('\nUpdating your current directory...')
+            with open(CURSOR_FILE) as f:
+                update(f.readline())
+                save_cursor()
+        
+        else:
+            print('\nWhile an nginx file directory was found, a Dropbox cursor was not.')
+            print('Since the cursor tells Dropbox how long ago this program last checked for updates, ')
+            print('the folder may be recreated automatically with the new cursor, or you can update it yourself.')
+            
+            if click.confirm('Would you like to automatically remove and recreate the folder with a new cursor?'):
+                shutil.rmtree(FILE_DIR)
+                download_folder(DROPBOX_FILE_DIR, BASE_DIR, rename=True, progress=True)
+                save_cursor()
+    
+    else:
+        print('\nNo nginx file directory found.')
+        download_folder(DROPBOX_FILE_DIR, BASE_DIR, rename=True, progress=True)
+        save_cursor()
+
+main()

--- a/misc/dropbox-sync.py
+++ b/misc/dropbox-sync.py
@@ -3,39 +3,31 @@ import json
 import os
 import requests
 import shutil
+import sys
 import zipfile
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FILE_DIR = f'{BASE_DIR}/file_data'
 ZIP_FILE= f'{BASE_DIR}/files.zip'
 CURSOR_FILE = f'{BASE_DIR}/cursor'
+LOG_FILE = f'{BASE_DIR}/dropbox-sync.log'
 
 DROPBOX_FILE_DIR='/colrc-v2-files'
 DROPBOX_ACCESS_TOKEN='H66L2R8JfX8AAAAAAAAAASyxUvZolCy956ASqQZjEPhFHXDbfa5zbk1pmNdsxYSA'
 
-# TODO: Split download_folder so that print statements don't appear in the middle of update() output
-def download_folder(folder, dl_location, rename=False, progress=False):
+def download_all(dl_location):
     """
-    Downloads a folder from Dropbox as a .zip file. 
+    Downloads everything at DROPBOX_FILE_DIR as a .zip file. 
     
     Parameters
     ----------
-    folder : str or int
-        The folder's path or ID in Dropbox
-    
     dl_location : str
-        The path to extract the zip file to on the local filesystem (excluding the name of the folder)
-
-    rename : bool, default=True
-        Internal use only; renames the extracted folder from the Dropbox app's root directory to "file_data"
-
-    progress : bool, default=False
-        Dynamically prints the download's progress in the terminal (isn't really necessary for single folders)
+        The path to extract the zip file to on the local filesystem (excluding the name of the folder, since it will be named FILE_DIR).
     """
 
     headers = {
         'Authorization': f'Bearer {DROPBOX_ACCESS_TOKEN}',
-        'Dropbox-API-Arg': f'{{"path": "{folder}"}}'
+        'Dropbox-API-Arg': f'{{"path": "{DROPBOX_FILE_DIR}"}}'
     }
     
     response = requests.post('https://content.dropboxapi.com/2/files/download_zip', headers=headers, stream=True)
@@ -46,15 +38,13 @@ def download_folder(folder, dl_location, rename=False, progress=False):
         for chunk in response.iter_content(chunk_size=1024):
             f.write(chunk)
             megabytes_written += 1/1024
-            if progress:
-                print(f'\r{megabytes_written:.0f}MB downloaded...', end='', flush=True)
+            print(f'\r{megabytes_written:.0f}MB downloaded...', end='', flush=True)
     
-    print('\nExtracting zip file...')
+    print('Extracting zip file...')
     with zipfile.ZipFile(ZIP_FILE, 'r') as z:
         z.filename = 'file_data'
         z.extractall(dl_location)
 
-    if rename:
         print('Renaming folder...')
         os.rename(f'{BASE_DIR}/{DROPBOX_FILE_DIR}', FILE_DIR)
 
@@ -68,17 +58,19 @@ def download_folder(folder, dl_location, rename=False, progress=False):
         for f in files:
             os.chmod(os.path.join(root, f), 0o777)
 
+    save_cursor()
+
 def download_file(file, dl_location):
     """
-    Downloads a folder from Dropbox as a .zip file. 
+    Downloads a file from Dropbox. 
     
     Parameters
     ----------
     file : str or int
-        The folder's path or ID in Dropbox
+        The file's path or ID in Dropbox.
     
     dl_location : str
-        The path to download the file to on the local filesystem (excluding the name of the folder)
+        The path to download the file to on the local filesystem.
     """
 
     headers = {
@@ -88,6 +80,9 @@ def download_file(file, dl_location):
     
     response = requests.post('https://content.dropboxapi.com/2/files/download', headers=headers)
     
+    if os.path.isdir(dl_location):
+        raise FileExistsError
+
     with open(dl_location, 'wb') as f:
         f.write(response.content)
             
@@ -125,44 +120,64 @@ def update(cursor):
     }
     data = f'{{"cursor": "{cursor}"}}'
 
-    updated_files = json.loads(requests.post('https://api.dropboxapi.com/2/files/list_folder/continue', headers=headers, data=data).content)
+    response = requests.post('https://api.dropboxapi.com/2/files/list_folder/continue', headers=headers, data=data)
+    updated_files = json.loads(response.content)
     
-    print('\nUpdating files:')
-    for entry in updated_files['entries']:
-        local_path = f'{FILE_DIR}{entry["path_display"].replace(DROPBOX_FILE_DIR, "")}'
+    if updated_files['entries']:
+        print('\nUpdating your current directory...')
+        for entry in updated_files['entries']:
+            local_path = f'{FILE_DIR}{entry["path_display"].replace(DROPBOX_FILE_DIR, "")}'
+            
+            if entry['.tag'] == 'deleted':
+                try:
+                    if os.path.isdir(local_path):
+                        shutil.rmtree(local_path)
+                        print(f'DEL {entry["name"]}')
+                    elif os.path.isfile(local_path):
+                        os.remove(local_path)
+                        print(f'DEL {entry["name"]}')
+                    else:
+                        print(f'DEX {entry["name"]}')
+                except:
+                    print(f'ERR DEL {entry["name"]}')
+            
+            elif entry['.tag'] == 'file':
+                try:
+                    download_file(entry['path_display'], local_path)
+                    os.chmod(local_path, 0o777)
+                    print(f'ADD {entry["name"]}')
+                except FileExistsError:
+                    print(f'AEX {entry["name"]}')
+                except:
+                    print(f'ERR ADD {entry["name"]}')
+            
+            elif entry['.tag'] == 'folder':
+                try:
+                    os.mkdir(local_path)
+                    os.chmod(local_path, 0o777)
+                    print(f'ADD {entry["name"]}')
+                except FileExistsError:
+                    print(f'AEX {entry["name"]}')
+                except:
+                    print(f'ERR ADD {entry["name"]}')
+            
+            else:
+                print(f'Unknown error has occurred. Please check the log (located at {LOG_FILE}) for details.')
+                with open(LOG_FILE, 'w') as f:
+                    f.write(response.content)
+                sys.exit(1)
         
-        if entry['.tag'] == 'deleted':
-            try:
-                if os.path.isdir(local_path):
-                    shutil.rmtree(local_path)
-                else:
-                    os.remove(local_path)
-                print(f'DEL {entry["name"]}')
-            except:
-                print(f'ERR DEL {entry["name"]}')
-        
-        elif entry['.tag'] == 'file':
-            try:
-                download_file(entry['path_display'], local_path)
-                print(f'ADD {entry["name"]}')
-            except:
-                print(f'ERR ADD {entry["name"]}')
-        
-        elif entry['.tag'] == 'folder':
-            try:
-                download_folder(entry['path_display'], local_path.replace(entry['name'], ''))
-                print(f'ADD {entry["name"]}')
-            except:
-                print(f'ERR ADD {entry["name"]}')
+        save_cursor()
+    
+    else:
+        print('\nNo files to update.')
 
 # TODO: Support longer output from Dropbox, which comes with its own cursor(s) 
 def main():
     if os.path.isdir(FILE_DIR):
         if os.path.isfile(CURSOR_FILE):
-            print('\nUpdating your current directory...')
             with open(CURSOR_FILE) as f:
                 update(f.readline())
-                save_cursor()
         
         else:
             print('\nWhile an nginx file directory was found, a Dropbox cursor was not.')
@@ -171,12 +186,10 @@ def main():
             
             if click.confirm('Would you like to automatically remove and recreate the folder with a new cursor?'):
                 shutil.rmtree(FILE_DIR)
-                download_folder(DROPBOX_FILE_DIR, BASE_DIR, rename=True, progress=True)
-                save_cursor()
+                download_all(BASE_DIR)
     
     else:
         print('\nNo nginx file directory found.')
-        download_folder(DROPBOX_FILE_DIR, BASE_DIR, rename=True, progress=True)
-        save_cursor()
+        download_all(BASE_DIR)
 
 main()

--- a/misc/dropbox-sync.py
+++ b/misc/dropbox-sync.py
@@ -13,7 +13,26 @@ CURSOR_FILE = f'{BASE_DIR}/cursor'
 DROPBOX_FILE_DIR='/colrc-v2-files'
 DROPBOX_ACCESS_TOKEN='H66L2R8JfX8AAAAAAAAAASyxUvZolCy956ASqQZjEPhFHXDbfa5zbk1pmNdsxYSA'
 
+# TODO: Split download_folder so that print statements don't appear in the middle of update() output
 def download_folder(folder, dl_location, rename=False, progress=False):
+    """
+    Downloads a folder from Dropbox as a .zip file. 
+    
+    Parameters
+    ----------
+    folder : str or int
+        The folder's path or ID in Dropbox
+    
+    dl_location : str
+        The path to extract the zip file to on the local filesystem (excluding the name of the folder)
+
+    rename : bool, default=True
+        Internal use only; renames the extracted folder from the Dropbox app's root directory to "file_data"
+
+    progress : bool, default=False
+        Dynamically prints the download's progress in the terminal (isn't really necessary for single folders)
+    """
+
     headers = {
         'Authorization': f'Bearer {DROPBOX_ACCESS_TOKEN}',
         'Dropbox-API-Arg': f'{{"path": "{folder}"}}'
@@ -50,6 +69,18 @@ def download_folder(folder, dl_location, rename=False, progress=False):
             os.chmod(os.path.join(root, f), 0o777)
 
 def download_file(file, dl_location):
+    """
+    Downloads a folder from Dropbox as a .zip file. 
+    
+    Parameters
+    ----------
+    file : str or int
+        The folder's path or ID in Dropbox
+    
+    dl_location : str
+        The path to download the file to on the local filesystem (excluding the name of the folder)
+    """
+
     headers = {
         'Authorization': f'Bearer {DROPBOX_ACCESS_TOKEN}',
         'Dropbox-API-Arg': f'{{"path": "{file}"}}'
@@ -61,6 +92,10 @@ def download_file(file, dl_location):
         f.write(response.content)
             
 def save_cursor():
+    """
+    Saves the cursor (or snapshot) of the Dropbox folder to a file.
+    """
+    
     headers = {
     'Authorization': f'Bearer {DROPBOX_ACCESS_TOKEN}',
     'Content-Type': 'application/json'
@@ -75,6 +110,15 @@ def save_cursor():
         f.write(cursor)
 
 def update(cursor):
+    """
+    Updates the local filesystem with changes from the Dropbox folder.
+
+    Parameters
+    ----------
+    cursor : str
+        The Dropbox cursor obtained from the last sync to update with.
+    """
+    
     headers = {
     'Authorization': f'Bearer {DROPBOX_ACCESS_TOKEN}',
     'Content-Type': 'application/json'
@@ -111,6 +155,7 @@ def update(cursor):
             except:
                 print(f'ERR ADD {entry["name"]}')
 
+# TODO: Support longer output from Dropbox, which comes with its own cursor(s) 
 def main():
     if os.path.isdir(FILE_DIR):
         if os.path.isfile(CURSOR_FILE):

--- a/misc/dropbox-sync.py
+++ b/misc/dropbox-sync.py
@@ -206,7 +206,7 @@ def main():
     else:
         if os.path.isfile(CURSOR_FILE_BACKUP) and os.path.isfile(ZIP_FILE):
             print('\nNo nginx file directory has been found, but the program can restore from a backup.')
-            if input('Would you like to restore an older state of the folder? (NOTE: You will still be able to update it once this  has finished.) [y,N] ') in ['y', 'Y', 'yes', 'Yes']:
+            if input('Would you like to restore an older state of the folder? (NOTE: You will still be able to update it once this has finished.) [y,N] ') in ['y', 'Y', 'yes', 'Yes']:
                 extract()
                 print('Restoring cursor...')
                 shutil.copy(CURSOR_FILE_BACKUP, CURSOR_FILE)

--- a/misc/dropbox-sync.py
+++ b/misc/dropbox-sync.py
@@ -1,4 +1,3 @@
-import click
 import json
 import os
 import requests
@@ -184,7 +183,8 @@ def main():
             print('Since the cursor tells Dropbox how long ago this program last checked for updates, ')
             print('the folder may be recreated automatically with the new cursor, or you can update it yourself.')
             
-            if click.confirm('Would you like to automatically remove and recreate the folder with a new cursor?'):
+            if input('Would you like to automatically remove and recreate the folder with a new cursor? [y,N] ') in ['y', 'Y', 'yes', 'Yes']:
+                print('Removing old directory...')
                 shutil.rmtree(FILE_DIR)
                 download_all(BASE_DIR)
     

--- a/misc/dropbox-sync.py
+++ b/misc/dropbox-sync.py
@@ -152,6 +152,11 @@ def update(cursor, save_new_cursor=True):
 def save_cursor(location):
     """
     Saves the cursor (or snapshot) of the Dropbox folder to a file.
+
+    Parameters
+    ----------
+    location : str
+        The location to make the cursor file at.
     """
     
     headers = {


### PR DESCRIPTION
Instead of having to run `curl` each time to download the entire Dropbox folder (which may take a while for some), I have written a script that uses Dropbox's API to do a single initial download and only get updates from then on. It utilizes a cursor (somewhat like Dropbox's version of a commit hash) and stores it in a file, so that way Dropbox knows the state of its folder the last time the script saw it.

This program will only reflect changes that are made on Dropbox's end, so changes that you make (so long as they don't have conflicting names) will persist across syncs. I plan to implement a feature to recover from the initial .zip file downloaded from Dropbox (since downloads can take upwards of 20 minutes), but at the moment it would be best to save the initial cursor file somewhere else as well so that you can remove the folder, re-extract, and drop the cursor file in.

This was tested solely on my PC (Linux) using Python v3.9.5, so further testing would be appreciated!