### PR TITLE
Import all data into elicitations table; make it editable and searchable

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,6 +31,7 @@ import Metadata from './pages/Metadata';
 import Log from './pages/Log';
 import Audios from './pages/Audios';
 import Elicitations from './pages/Elicitations';
+import EditElicitation from "./pages/EditElicitation";
 import Spelling from './pages/Spelling';
 import Bibliography from './pages/Bibliography';
 import Search from './pages/Search';
@@ -159,6 +160,7 @@ function App(props) {
               <Route path="/imageviewer" component={ImageViewer} />
               <Route path="/splitview" component={SplitView} />
               <PrivateRoute path="/elicitations" component={Elicitations} key="Elicitations" />
+              <PrivateRoute path="/editelicitation" component={EditElicitation} key="EditElicitation" />
               <PrivateRoute path="/addaffix" component={AddAffix} key="AddAffix" />
               <PrivateRoute path="/editaffix" component={EditAffix} key="EditAffix" />
               <PrivateRoute path="/deleteaffix" component={DeleteAffix} key="DeleteAffix" />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,6 +21,7 @@ import EditRoot from './pages/EditRoot';
 import DeleteRoot from './pages/DeleteRoot';
 import AffixHistory from './pages/AffixHistory';
 import RootHistory from './pages/RootHistory';
+import ElicitationHistory from "./pages/ElicitationHistory";
 import UserList from './pages/UserList';
 import AddUser from './pages/AddUser';
 import Affixes from './pages/Affixes';
@@ -172,6 +173,7 @@ function App(props) {
               <PrivateRoute path="/deleteroot" component={DeleteRoot} key="DeleteRoot" /> 
               <PrivateRoute path="/affixhistory" component={AffixHistory} key="AffixHistory" />
               <PrivateRoute path="/roothistory" component={RootHistory} key="RootHistory" />
+              <PrivateRoute path="/elicitationhistory" component={ElicitationHistory} key="ElicitationHistory" />
               <PrivateRoute path="/log" component={Log} key="Log" />
               <PrivateRoute path="/users" component={Users} key="Users" />
               <PrivateRoute path="/userprofile" component={UserProfile} key="UserProfile" />

--- a/frontend/src/access/permissions.js
+++ b/frontend/src/access/permissions.js
@@ -12,6 +12,7 @@ export const path_role_permissions = {
     '/deleteroot': ['manager', 'update'],
     '/affixhistory': ['manager', 'update'],
     '/roothistory': ['manager', 'update'],
+    '/elicitationhistory': ['manager', 'update'],
     '/addstem': ['manager', 'update'],
     '/editstem': ['manager', 'update'],
     '/deletestem': ['manager', 'update'],

--- a/frontend/src/access/permissions.js
+++ b/frontend/src/access/permissions.js
@@ -17,6 +17,7 @@ export const path_role_permissions = {
     '/deletestem': ['manager', 'update'],
     '/stemhistory': ['manager', 'update'],
     '/elicitations': ['manager', 'update'],
+    '/editelicitation': ['manager', 'update'],
     '/log': ['manager', 'update'],
     '/home' : ['*'],
 }

--- a/frontend/src/pages/EditElicitation.js
+++ b/frontend/src/pages/EditElicitation.js
@@ -1,0 +1,237 @@
+import React, { useState } from "react";
+import { Redirect, useLocation, useHistory } from 'react-router-dom';
+import { getElicitationSetByIdQuery, updateElicitationSetMutation } from './../queries/queries'
+import { Button, Input, Label, Grid, Header, Message } from 'semantic-ui-react';
+import * as Yup from 'yup';
+import { Formik, Form } from 'formik';
+import { useAuth } from "../context/auth";
+import { useQuery } from '@apollo/react-hooks'
+import { handleErrors, broadCastSuccess } from '../utils/messages';
+import { confirmAlert } from 'react-confirm-alert';
+import '../stylesheets/react-confirm-alert.css';
+
+let updateElicitationSchema = Yup.object().shape({
+  language: Yup.string()
+    .required('a transcription language is required'),
+  prompt: Yup.string()
+    .required('an elicitation prompt is required'),
+  editnote: Yup.string()
+    .required('an edit note is required'),
+  speaker: Yup.string()
+    .required('a speaker is required'), 
+  transcription: Yup.string()
+    .required('an elicitation transcription is required')
+  });
+
+function EditElicitation() {
+  const { client } = useAuth();
+  const [ hasUpdated, setHasUpdated] = useState(false)
+  const search = new URLSearchParams(useLocation().search)
+  const id = search.get("id")
+  const history = useHistory()
+
+
+  let { loading: elicitationLoading, error: elicitationError, data: elicitationData } = useQuery(getElicitationSetByIdQuery, {client: client, variables: {id: id} }) 
+   
+  if (elicitationLoading) {
+      return <div>loading...</div>
+  }
+  if (elicitationError) {
+      return <div>Something went wrong</div>
+  }
+
+  async function onFormSubmit (values, setSubmitting) {
+    try {
+      const result = await client.mutate({
+        mutation: updateElicitationSetMutation,
+        variables: {
+          id: values.id,
+          editnote: values.editnote,
+          language: values.language,
+          prompt: values.prompt,
+          speaker: values.speaker,
+          transcription: values.transcription
+        }
+      })
+      if (result.error) {
+        handleErrors(result.error)
+        setSubmitting(false)
+      } else {
+        broadCastSuccess(`elicitation set ${values.transcription} successfully edited!`)
+        setSubmitting(false)
+        setHasUpdated(true)
+      }
+    } catch (error) {
+      handleErrors(error)
+      setSubmitting(false)
+    }
+  }
+
+  if (hasUpdated) {
+    return <Redirect to="/elicitations" />;
+  }
+
+  const routeChange=()=> {
+    let path = `/elicitations`;
+    history.push(path);
+  }
+
+
+  return (
+    <>
+    <Grid centered>
+        <Grid.Row>
+            <Grid.Column textAlign="center" width={12}>
+                <Header as="h2">Edit an Elicitation Set</Header>
+                <Message>The elements whose labels are solid blue are required for all elicitation sets.  The elements whose labels are outlined may be blank.</Message>
+            </Grid.Column>
+        </Grid.Row>
+    </Grid>
+    <Formik 
+        initialValues={{ 
+        id: elicitationData.elicitationsets_by_pk.id,
+        language: elicitationData.elicitationsets_by_pk.language ? elicitationData.elicitationsets_by_pk.language : "" ,
+        prompt: elicitationData.elicitationsets_by_pk.prompt ? elicitationData.elicitationsets_by_pk.prompt : "" ,
+        speaker: elicitationData.elicitationsets_by_pk.speaker ? elicitationData.elicitationsets_by_pk.speaker : "" ,
+        transcription: elicitationData.elicitationsets_by_pk.transcription ? elicitationData.elicitationsets_by_pk.transcription : "" ,
+        editnote: elicitationData.elicitationsets_by_pk.editnote ? elicitationData.elicitationsets_by_pk.editnote : "" 
+        }}
+        validationSchema={updateElicitationSchema}
+        onSubmit={(values, { setSubmitting }) => {
+            confirmAlert({
+                title: 'Confirm to submit',
+                message: 'Are you sure you want to edit the elicitation set?',
+                buttons: [
+                  {
+                    label: 'Yes',
+                    onClick: () => onFormSubmit(values, setSubmitting)
+                  },
+                  {
+                    label: 'No',
+                    onClick: () => setSubmitting(false)
+                  }
+                ]
+              });
+        }}>
+        
+        {({ isSubmitting, values, errors, touched, handleChange, handleBlur, setFieldValue }) => (
+        <Form>
+            <Grid centered>
+                <Grid.Row>
+                    <Grid.Column width={2} textAlign="right"><Label pointing="right" color="blue">Language</Label></Grid.Column>
+                    <Grid.Column width={10}>
+                        <Input
+                            fluid
+                            style={{ paddingBottom: '5px' }}
+                            id="language"
+                            placeholder="language"
+                            type="text"
+                            value={ values.language }
+                            onChange={ handleChange }
+                            onBlur={ handleBlur }
+                            className={ errors.language && touched.language ? 'text-input error' : 'text-input' }
+                        />
+                        {errors.language && touched.language && ( <div className="input-feedback">{errors.language}</div>
+                        )}
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
+                    <Grid.Column width={2} textAlign="right"><Label pointing="right" color="blue">Prompt</Label></Grid.Column>
+                    <Grid.Column width={10}>
+                        <Input
+                            fluid
+                            style={{ paddingBottom: '5px' }}
+                            id="prompt"
+                            placeholder="prompt"
+                            type="text"
+                            value={ values.prompt }
+                            onChange={ handleChange }
+                            onBlur={ handleBlur }
+                            className={ errors.prompt && touched.prompt ? 'text-input error' : 'text-input' }
+                        />
+                        {errors.prompt && touched.prompt && ( <div className="input-feedback">{errors.prompt}</div>
+                        )}
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
+                    <Grid.Column width={2} textAlign="right"><Label pointing="right" color="blue">Transcription</Label></Grid.Column>
+                    <Grid.Column width={10}>
+                        <Input
+                            fluid
+                            style={{ paddingBottom: '5px' }}
+                            id="transcription"
+                            placeholder="transcription"
+                            type="text"
+                            value={ values.transcription }
+                            onChange={ handleChange }
+                            onBlur={ handleBlur }
+                            className={ errors.transcription && touched.transcription ? 'text-input error' : 'text-input'}
+                        />
+                        {errors.transcription && touched.transcription && ( <div className="input-feedback">{errors.transcription}</div>
+                        )}
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
+                    <Grid.Column width={2} textAlign="right"><Label basic pointing="right" color="blue">Speaker</Label></Grid.Column>
+                    <Grid.Column width={10}>
+                        <Input
+                            fluid
+                            style={{ paddingBottom: '5px' }}
+                            id="speaker"
+                            placeholder="speaker"
+                            type="text"
+                            value={ values.speaker }
+                            onChange={ handleChange }
+                            onBlur={ handleBlur }
+                            className={ errors.speaker && touched.speaker ? 'text-input error' : 'text-input' }
+                        />
+                        {errors.speaker && touched.speaker && ( <div className="input-feedback">{errors.speaker}</div>
+                        )}
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
+                    <Grid.Column width={2} textAlign="right"><Label pointing="right" color="blue">Note</Label></Grid.Column>
+                    <Grid.Column width={10}>
+                        <Input
+                            fluid
+                            style={{ paddingBottom: '5px' }}
+                            id="editnote"
+                            placeholder="An edit note is required"
+                            type="text"
+                            value={ values.editnote }
+                            onChange={ handleChange }
+                            onBlur={ handleBlur }
+                            className={ errors.editnote && touched.editnote ? 'text-input error' : 'text-input' }
+                        />
+                        {errors.editnote && touched.editnote && ( <div className="input-feedback">{errors.editnote}</div>
+                        )}
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
+                    <Grid.Column width={4}>
+                        <Button 
+                            fluid
+                            color="blue"  
+                            type="submit" 
+                            disabled={isSubmitting}
+                        >
+                            Submit
+                        </Button>
+                    </Grid.Column>
+                    <Grid.Column width={4}>
+                        <Button onClick={routeChange}
+                            fluid
+                        >
+                            Cancel
+                        </Button>
+                    </Grid.Column>
+                </Grid.Row>
+            </Grid>
+        </Form>
+         )}
+    </Formik>
+    </>
+  );
+}
+
+export default EditElicitation;

--- a/frontend/src/pages/ElicitationHistory.js
+++ b/frontend/src/pages/ElicitationHistory.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { useLocation } from 'react-router-dom';
+import { useAuth } from "../context/auth";
+import { getElicitationSetHistoryByIdQuery } from '../queries/queries'
+import { useQuery } from '@apollo/react-hooks'
+
+function ElicitationHistory(props) {
+    const { client } = useAuth();
+    const search = new URLSearchParams(useLocation().search)
+    const id = search.get("id")
+    console.log(id)
+  
+    let { loading, error, data } = useQuery(getElicitationSetHistoryByIdQuery, 
+        {client: client, variables: {"table_name": "elicitationsets", "row_data": {"id": parseInt(id)}} })
+        
+    console.log(data)
+     
+    if (loading) {
+      return <div>loading...</div>
+    }
+    if (error) {
+      return <div>Something went wrong</div>
+    }
+    console.log(data.audit_logged_actions)
+
+    return(JSON.stringify(data.audit_logged_actions.map(elem => {
+        return { action: elem.action, userId: elem.hasura_user["x-hasura-user-id"], prompt: elem.row_data.prompt, transcription: elem.row_data.transcription}
+      })))
+    
+}
+
+export default ElicitationHistory

--- a/frontend/src/pages/ElicitationsTable.js
+++ b/frontend/src/pages/ElicitationsTable.js
@@ -1,11 +1,13 @@
 import React from 'react'
+import { Link,useHistory } from 'react-router-dom';
 import { useTable, usePagination, useSortBy, useFilters, useGlobalFilter } from 'react-table'
-import { DefaultColumnFilter, GlobalFilter, fuzzyTextFilterFn } from '../utils/Filters'
+import { DefaultColumnFilter, GlobalFilter, fuzzyTextFilterFn, SelectColumnFilter } from '../utils/Filters'
 import { useAuth } from "../context/auth";
 import { getElicitationSetsQuery } from './../queries/queries'
 import ElicitationsPlayer from '../utils/ElicitationsPlayer';
 import { sortReshape, filterReshape } from "./../utils/reshapers"
 import TableStyles from "./../stylesheets/table-styles"
+import { Icon, Button } from "semantic-ui-react";
 
 function Table({
   columns,
@@ -236,7 +238,40 @@ function ElicitationsTable(props) {
   const columns = React.useMemo(
     () => [
       {
+        Header: 'History/Edit',
+        disableFilters: true,
+        sortable: false,
+        width: 100,
+        show: true,
+        id: 'historyEdit',
+        label: 'History/Edit',
+        tableName: 'ElicitationsTable',
+        Cell: ({row, original}) => (
+          <div className="buttons">
+            <Link 
+              to={{
+                pathname: "/elicitationhistory",
+                search: "?id=" + row.original.id,
+              }}>
+              <button className="ui mini blue icon button">
+                <Icon name="history" />
+              </button>              
+            </Link>
+            <Link 
+              to={{
+                pathname: "/editelicitation",
+                search: "?id=" + row.original.id,
+              }}>
+              <button className="ui mini black icon button">
+                <Icon name="edit" />
+              </button>              
+            </Link>
+          </div>
+        )
+      }, 
+      {
         Header: 'Audio',
+        disableFilters: true,
         id: 'audio',
         accessor: 'elicitationsets_elicitationfiles', 
         show: true,

--- a/frontend/src/pages/ElicitationsTable.js
+++ b/frontend/src/pages/ElicitationsTable.js
@@ -254,7 +254,7 @@ function ElicitationsTable(props) {
       },
       {
         Header: 'Prompt',
-        accessor: 'title',
+        accessor: 'prompt',
         tableName: 'Elicitations',
         show: true,
         id: 'prompt',
@@ -307,6 +307,7 @@ async function getElicitations(limit, offset, sortBy, filters) {
     // }
     // console.log("this is res.data ", res.data)
     // console.log("this is texts ", texts)
+    console.log(res.data)
     return res.data
   }  
 

--- a/frontend/src/pages/ElicitationsTable.js
+++ b/frontend/src/pages/ElicitationsTable.js
@@ -248,7 +248,7 @@ function ElicitationsTable(props) {
         Header: 'Transcription',
         accessor: 'transcription',
         tableName: 'Elicitations',
-        show: false,
+        show: true,
         id: 'transcription',
         label: 'Transcription'
       },
@@ -272,7 +272,7 @@ function ElicitationsTable(props) {
         Header: 'Language',
         accessor: 'language',
         tableName: 'Elicitations',
-        show: true,
+        show: false,
         id: 'language',
         label: 'Language'
       }

--- a/frontend/src/pages/ElicitationsTable.js
+++ b/frontend/src/pages/ElicitationsTable.js
@@ -362,7 +362,7 @@ const fetchData = React.useCallback(({ pageSize, pageIndex, sortBy, filters, glo
   setTimeout(() => {
     if (fetchId === fetchIdRef.current) {
       const controlledSort = sortReshape(sortBy) 
-      const controlledFilter = filterReshape(filters, globalFilter, [])
+      const controlledFilter = filterReshape(filters, globalFilter, ["language", "prompt", "speaker", "transcription"])
       getElicitations(pageSize, pageSize * pageIndex, controlledSort, controlledFilter)
       .then((data) => {
         let totalCount = data.elicitationsets_aggregate.aggregate.count

--- a/frontend/src/queries/queries.js
+++ b/frontend/src/queries/queries.js
@@ -261,6 +261,31 @@ export const getElicitationSetByIdQuery = gql`
   }
 `;
 
+export const getElicitationSetHistoryByIdQuery = gql`
+  query getElicitationSetHistoryById($row_data: jsonb!, $table_name: String!) {
+    audit_logged_actions(where: {table_name: {_eq: $table_name}, row_data: {_contains: $row_data}}, order_by: {action_tstamp_clk: asc})  {
+      action
+      action_tstamp_clk
+      action_tstamp_stm
+      action_tstamp_tx
+      application_name
+      changed_fields
+      client_addr
+      client_port
+      client_query
+      event_id
+      hasura_user
+      relid
+      row_data
+      schema_name
+      session_user_name
+      statement_only
+      table_name
+      transaction_id
+    }
+  } 
+`;
+
 // getLogs
 
 export const getLogQuery = gql`

--- a/frontend/src/queries/queries.js
+++ b/frontend/src/queries/queries.js
@@ -229,7 +229,7 @@ export const getElicitationSetsQuery = gql`
       id
       language
       speaker
-      title
+      prompt
       transcription
       user {
         email

--- a/frontend/src/queries/queries.js
+++ b/frontend/src/queries/queries.js
@@ -249,6 +249,18 @@ export const getElicitationSetsQuery = gql`
   }
 `;
 
+export const getElicitationSetByIdQuery = gql`
+  query GetElicitationById($id: Int!) {
+    elicitationsets_by_pk(id: $id) {
+      id
+      language
+      prompt
+      speaker
+      transcription
+    }
+  }
+`;
+
 // getLogs
 
 export const getLogQuery = gql`
@@ -989,6 +1001,30 @@ export const updateAffixMutation = gql`
     }
   }
 `;
+
+export const updateElicitationSetMutation = gql `
+  mutation updateAnElicitation($id: Int!, $editnote: String!, $language: String!, $prompt: String!, $speaker: String!, $transcription: String!) {
+    update_elicitationsets_by_pk(pk_columns: {id: $id},
+      _set: {
+        editnote: $editnote,
+        language: $language,
+        prompt: $prompt
+        speaker: $speaker
+        transcription: $transcription
+      }
+    )
+    {
+      createdAt
+      editnote
+      id
+      language
+      prompt
+      transcription
+      updatedAt
+      userId
+    }
+  }
+`
 
 export const updateRootMutation = gql`
   mutation updateARoot($id: Int!, $editnote: String!, $english: String!, $salish: String, $nicodemus: String!, $root: String!, $number: Int, $sense: String, $symbol: String, $grammar: String, $crossref: String, $variant: String, $cognate: String){


### PR DESCRIPTION
Fixes #111, where the elicitations table was incomplete, uneditable by users with permission, and unsearchable.

The table now contains all of the entries (from `sloat_index.xlsx` in our Google Drive) and contains references to all of the audio files based on `elicitationSetId` (thus the audio for an elicitation set with the ID of 2920 would be `2920.wav`).

Additionally, an edit page along with a basic history page have been created based on our other tables.

Everything works as intended and was tested on Firefox 89. Would be great if someone else could test this as well!