### PR TITLE
Add secondary sort by ID to fix sorting behavior

### DIFF
--- a/frontend/src/utils/reshapers.js
+++ b/frontend/src/utils/reshapers.js
@@ -10,7 +10,7 @@ export function sortReshape(sortBy) {
         }
         res.push(h)
     })
-
+    res.push({"id": "asc"})
     console.log("The result of the sort: ", res)
     
     return(res)


### PR DESCRIPTION
When a limit/offset is imposed during a query, and the database items have the same fields and are being sorted by these fields, the results can be very unpredictable. 

In the case of the texts table, we noticed that we were sorting by cycle and that most of these items were a part of the "Coyote Cycle." Normally the order of these wouldn't matter, but by imposing a limit on the number of results each query could return, the subsequent queries had no way of knowing what the previous ones returned. By default, this led to multiple duplicate results and some results that didn't show up at all.

Since `sortReshape()` is called by each table, I added an implicit secondary sort by ID so that each item is sorted predictably and we no longer get duplicate/missing results. Since this solution works globally, we should no longer see this behavior in any of the other tables.

This was tested on Firefox 89, and from what I can tell no anomalous results seem to appear in any of the tables. Resolves #149.