### PR TITLE
Show full log history in subtable

### DIFF
--- a/frontend/src/pages/LogSubTable.js
+++ b/frontend/src/pages/LogSubTable.js
@@ -1,5 +1,6 @@
 import React from "react";
 import {useTable} from "react-table";
+import { formatCell } from '../utils/helpers'
 
 
 function Table({ columns, data }) {
@@ -8,8 +9,18 @@ function Table({ columns, data }) {
     getTableBodyProps,
     headerGroups,
     rows,
-    prepareRow
+    prepareRow,
+    setHiddenColumns,
   } = useTable({columns, data})
+
+  React.useEffect(
+    () => {
+      setHiddenColumns(
+        columns.filter(column => column.hide).map(column => column.id)
+      );
+    },
+    [columns, setHiddenColumns]
+  );
 
   // Render the UI for your table
   return (
@@ -44,16 +55,26 @@ function Table({ columns, data }) {
 }
 
 function LogSubTable({ rowData, modifiedRows }) {
+  const isUpdate = !!(modifiedRows !== null && rowData !== modifiedRows)
   const columns = React.useMemo(
-    () => Object.keys(rowData).map(
-            key => ({
-              Header: modifiedRows && key in modifiedRows ? (<mark>{key}</mark>) : key, 
-              id: key, 
-              accessor: (obj) => obj[key] || "NULL"}
-            )
-    ), [])
-  const [data] = React.useState(() => [rowData]);
-
+    () => [
+      {
+        Header: '',
+        id: 'before_or_after',
+        accessor: (obj) => obj === rowData ? 'Before' : 'After',
+        hide: !isUpdate
+      },
+      ...Object.keys(rowData).map(
+        key => ({
+          Header: modifiedRows && key in modifiedRows 
+                  ? (<span style={{backgroundColor: "#88bbff"}}>{key}</span>) 
+                  : key, 
+          id: key, 
+          accessor: (obj) => formatCell(obj[key] || rowData[key] || "NULL")
+        })
+    )], [])
+  const [data] = React.useState(() => (isUpdate ? [rowData, modifiedRows] : [rowData]));
+  console.log(columns)
   return (
     <Table 
         columns={columns} 

--- a/frontend/src/pages/LogSubTable.js
+++ b/frontend/src/pages/LogSubTable.js
@@ -63,7 +63,6 @@ function Table({ columns, data, fetchData, getCellProps }) {
 
 function LogSubTable({ originalRow }) {
   function getCellProps(cell) {
-    console.log(cell)
     var header = cell.column.key
     var modifiedRows = cell.row.original.changed_fields
 

--- a/frontend/src/pages/LogTable.js
+++ b/frontend/src/pages/LogTable.js
@@ -309,20 +309,6 @@ function LogTable(props) {
         tableName: 'LogTable',
         id: 'user',
         label: 'user'
-      },
-
-      // Helper Fields
-      {
-        hide: true,
-        accessor: 'row_data',
-        tableName: 'LogTable',
-        id: 'row_data',
-      },
-      {
-        hide: true,
-        accessor: 'changed_fields',
-        tableName: 'LogTable',
-        id: 'changed_fields',
       }
     ], []
   )

--- a/frontend/src/pages/LogTable.js
+++ b/frontend/src/pages/LogTable.js
@@ -106,7 +106,7 @@ function Table({
   React.useEffect(
     () => {
       setHiddenColumns(
-        columns.filter(column => !column.show).map(column => column.id)
+        columns.filter(column => column.hide).map(column => column.id)
       );
     },
     [columns, setHiddenColumns]
@@ -271,9 +271,8 @@ function LogTable(props) {
   const updateColumns = React.useMemo(
     () => [
        {
-        Header: () => null, // No header
+        Header: '',
         id: 'expander', // It needs an ID
-        show: true,
         Cell: ({ row }) => (
            <span {...row.getToggleRowExpandedProps()}>
               {row.isExpanded ? '▼' : '▶'}
@@ -285,7 +284,6 @@ function LogTable(props) {
         accessor: 'action',
         Filter: DefaultColumnFilter,
         tableName: 'LogTable',
-        show: true,
         id: 'action',
         label: 'action'
       },
@@ -294,7 +292,6 @@ function LogTable(props) {
         accessor: 'schema_name',
         Filter: DefaultColumnFilter,
         tableName: 'LogTable',
-        show: false,
         id: 'schema_name',
         label: 'schema'
       },
@@ -302,7 +299,6 @@ function LogTable(props) {
         Header: 'Table',
         accessor: 'table_name',
         tableName: 'LogTable',
-        show: true,
         id: 'table_name',
         label: 'table'
       },
@@ -311,20 +307,19 @@ function LogTable(props) {
         accessor: 'audit_user[0].first',
         filter: 'fuzzyText',
         tableName: 'LogTable',
-        show: true,
         id: 'user',
         label: 'user'
       },
 
       // Helper Fields
       {
-        show: false,
+        hide: true,
         accessor: 'row_data',
         tableName: 'LogTable',
         id: 'row_data',
       },
       {
-        show: false,
+        hide: true,
         accessor: 'changed_fields',
         tableName: 'LogTable',
         id: 'changed_fields',
@@ -337,7 +332,8 @@ function LogTable(props) {
          <div>
             <LogSubTable 
               rowData={row.values.row_data} 
-              modifiedRows={row.original.changed_fields} />
+              modifiedRows={row.original.changed_fields}
+              tableName={row.values.table_name} />
          </div>
       ),
       []
@@ -365,17 +361,6 @@ function LogTable(props) {
          }
       })
     }
-    // else {
-    //   res = await client.query({
-    //     query: getAnonAffixesQuery,
-    //     variables: { 
-    //       limit: limit,
-    //       offset: offset,
-    //       affix_order: sortBy,
-    //       where: filters,
-    //     }
-    //   })
-    // }
     return res.data
   }  
 

--- a/frontend/src/pages/LogTable.js
+++ b/frontend/src/pages/LogTable.js
@@ -330,10 +330,7 @@ function LogTable(props) {
   const renderRowSubComponent = React.useCallback(
       ({ row }) => (
          <div>
-            <LogSubTable 
-              rowData={row.values.row_data} 
-              modifiedRows={row.original.changed_fields}
-              tableName={row.values.table_name} />
+            <LogSubTable originalRow={row} />
          </div>
       ),
       []

--- a/frontend/src/queries/queries.js
+++ b/frontend/src/queries/queries.js
@@ -424,6 +424,7 @@ export const getLogQuery = gql`
       }
     }
     audit_logged_actions(limit: $limit, offset: $offset, where: $where, order_by: $log_order) {
+      event_id
       action
       changed_fields
       hasura_user

--- a/frontend/src/queries/queries.js
+++ b/frontend/src/queries/queries.js
@@ -441,6 +441,20 @@ export const getLogQuery = gql`
   }
 `;
 
+export const getRowHistoryQuery = gql`
+  query getLogQuery($row_contains: jsonb, $table_name: String) {
+    audit_logged_actions(where: {row_data: {_contains: $row_contains}, table_name: {_eq: $table_name}}, order_by: {event_id: desc}) {
+      event_id
+      action
+      row_data
+      changed_fields
+      audit_user {
+        first
+      }
+    }
+  }
+`
+
 // getMetadata
 
 export const getMetadataLexiconQuery = gql `

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -135,7 +135,7 @@ export function findDecorations(str) {
   return decorations;
 }
 
-export function formatCell(contents) {
+export function formatCellValue(contents) {
   if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}\+\d{2}:\d{2}/.test(contents)) {
     return new Date(contents).toLocaleString()
   }

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -136,9 +136,21 @@ export function findDecorations(str) {
 }
 
 export function formatCellValue(contents) {
+  // Null
+  if (contents === null) {
+    return 'NULL'
+  }
+
+  // Object
+  if (typeof contents === "object") {
+    return JSON.stringify(contents)
+  }
+
+  // Raw ISO Date
   if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}\+\d{2}:\d{2}/.test(contents)) {
     return new Date(contents).toLocaleString()
   }
+
   // Eventually add more formatters...
   return contents;
 }

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -147,7 +147,7 @@ export function formatCellValue(contents) {
   }
 
   // Raw ISO Date
-  if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}\+\d{2}:\d{2}/.test(contents)) {
+  if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+\+\d{2}:\d{2}/.test(contents)) {
     return new Date(contents).toLocaleString()
   }
 

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -134,3 +134,11 @@ export function findDecorations(str) {
 
   return decorations;
 }
+
+export function formatCell(contents) {
+  if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}\+\d{2}:\d{2}/.test(contents)) {
+    return new Date(contents).toLocaleString()
+  }
+  // Eventually add more formatters...
+  return contents;
+}


### PR DESCRIPTION
![Screenshot_2023-09-27_at_10 32 17_PM](https://github.com/arizona-linguistics/colrc-v2/assets/4073569/cce26b2d-7179-4495-b9a9-b251fb71bbea)

I like this one a lot more than #272.  Please only merge one.

Meanings:
* Dark color: This row was updated 
* Green: This is the current row (the specific action that you're opening the dropdown menu of)

Additional Features:
* Some updates have no changes at all.  I've marked these with an X as the action rather than U
<img width="1014" alt="Screenshot 2023-09-27 at 10 36 07 PM" src="https://github.com/arizona-linguistics/colrc-v2/assets/4073569/653dc08b-5d94-4a3f-8d9d-02b3afd4777a">

Issues:
* This will show the history of ALL rows with the same ID.  If there's a row with ID 2 and it gets deleted and another row is created that gets its old ID, it will show the histories of both.  

<img width="827" alt="Many roles with the ID 2" src="https://github.com/arizona-linguistics/colrc-v2/assets/4073569/b37d25ca-cdc2-4875-83e6-66e5f2c6f192">

Closes  #268
