### PR TITLE
Add expand all button

### DIFF
--- a/frontend/src/pages/LogTable.js
+++ b/frontend/src/pages/LogTable.js
@@ -16,7 +16,9 @@ function Table({
   fetchData,
   loading,
   pageCount: controlledPageCount,
-  renderRowSubComponent
+  renderRowSubComponent,
+  allExpanded, 
+  setAllExpanded
 //   selectValues
 }) {
   const { user } = useAuth();
@@ -70,6 +72,7 @@ function Table({
     nextPage,
     previousPage,
     setPageSize,
+    toggleAllRowsExpanded,
     // Get the state from the instance
     state: { pageIndex, pageSize, sortBy, filters, globalFilter }
   } = useTable(
@@ -112,6 +115,11 @@ function Table({
     [columns, setHiddenColumns]
   );
 
+  React.useEffect(
+    () => {toggleAllRowsExpanded(allExpanded)},
+    [allExpanded, loading]
+  );
+
   // Render the UI for your table
   return (
     <>
@@ -133,6 +141,13 @@ function Table({
           )}
         </code>
       </pre> */}
+      <div className="allExpandToggle">
+        <label>
+          <input type="checkbox" onClick={(e) => setAllExpanded(e.target.checked)}/>{' '}
+          {"Expand All"}
+        </label>
+      </div>
+
       <div className="columnToggle">
         {allColumns.map(column => (
          (column.label !== undefined) ?
@@ -348,6 +363,7 @@ function LogTable(props) {
   const [data, setData] = React.useState([])
   const [loading, setLoading] = React.useState(false)
   const [pageCount, setPageCount] = React.useState(0)
+  const [allExpanded, setAllExpanded] = React.useState(false)
   const fetchIdRef = React.useRef(0)
   const { client, setAuthTokens, user } = useAuth();
 
@@ -435,6 +451,8 @@ function LogTable(props) {
         loading={loading}
         pageCount={pageCount}
         // selectValues={props.selectValues}
+        allExpanded={allExpanded}
+        setAllExpanded={setAllExpanded}
       />
     </TableStyles>
   )

--- a/frontend/src/pages/LogTable.js
+++ b/frontend/src/pages/LogTable.js
@@ -17,8 +17,7 @@ function Table({
   loading,
   pageCount: controlledPageCount,
   renderRowSubComponent,
-  allExpanded, 
-  setAllExpanded
+  setExpandAllChecked
 //   selectValues
 }) {
   const { user } = useAuth();
@@ -103,8 +102,8 @@ function Table({
 
   // Listen for changes in pagination and use the state to fetch our new data
   React.useEffect(() => {
-    fetchData({ pageIndex, pageSize, sortBy, filters, globalFilter })
-  }, [fetchData, pageIndex, pageSize, sortBy, filters, globalFilter])
+    fetchData({ pageIndex, pageSize, sortBy, filters, globalFilter, toggleAllRowsExpanded })
+  }, [fetchData, pageIndex, pageSize, sortBy, filters, globalFilter, toggleAllRowsExpanded])
 
   React.useEffect(
     () => {
@@ -113,11 +112,6 @@ function Table({
       );
     },
     [columns, setHiddenColumns]
-  );
-
-  React.useEffect(
-    () => {toggleAllRowsExpanded(allExpanded)},
-    [allExpanded, loading]
   );
 
   // Render the UI for your table
@@ -143,8 +137,10 @@ function Table({
       </pre> */}
       <div className="allExpandToggle">
         <label>
-          <input type="checkbox" onClick={(e) => setAllExpanded(e.target.checked)}/>{' '}
-          {"Expand All"}
+          <input type="checkbox" onChange={(e) => {
+            setExpandAllChecked(e.target.checked);
+            toggleAllRowsExpanded(e.target.checked);}}/>
+          {' Expand All'}
         </label>
       </div>
 
@@ -363,7 +359,7 @@ function LogTable(props) {
   const [data, setData] = React.useState([])
   const [loading, setLoading] = React.useState(false)
   const [pageCount, setPageCount] = React.useState(0)
-  const [allExpanded, setAllExpanded] = React.useState(false)
+  const [expandAllChecked, setExpandAllChecked] = React.useState(false)
   const fetchIdRef = React.useRef(0)
   const { client, setAuthTokens, user } = useAuth();
 
@@ -396,7 +392,7 @@ function LogTable(props) {
   }  
 
 
-  const fetchData = React.useCallback(({ pageSize, pageIndex, sortBy, filters, globalFilter }) => {
+  const fetchData = React.useCallback(({ pageSize, pageIndex, sortBy, filters, globalFilter, toggleAllRowsExpanded }) => {
     // This will get called when the table needs new data
     // You could fetch your data from literally anywhere,
     // even a server. But for this example, we'll just fake it.
@@ -424,6 +420,7 @@ function LogTable(props) {
           setData(data.audit_logged_actions)
           setPageCount(Math.ceil(totalCount / pageSize))
           setLoading(false)
+          toggleAllRowsExpanded(expandAllChecked)
         })
         .catch((error) => {
           console.log(error)
@@ -436,7 +433,7 @@ function LogTable(props) {
       }
     }, 1000)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [history, setAuthTokens])
+  }, [history, setAuthTokens, expandAllChecked])
 
   let columns = updateColumns
   
@@ -451,8 +448,7 @@ function LogTable(props) {
         loading={loading}
         pageCount={pageCount}
         // selectValues={props.selectValues}
-        allExpanded={allExpanded}
-        setAllExpanded={setAllExpanded}
+        setExpandAllChecked={setExpandAllChecked}
       />
     </TableStyles>
   )

--- a/frontend/src/pages/MaterialsTable.js
+++ b/frontend/src/pages/MaterialsTable.js
@@ -4,7 +4,7 @@ import AudioPlayer from '../utils/AudioPlayer';
 import { Link } from 'react-router-dom';
 
 
-function Table({ columns, data, renderRowSubComponent }) {
+function Table({ columns, data, renderRowSubComponent, allExpanded }) {
    
   const {
     getTableProps,
@@ -12,7 +12,8 @@ function Table({ columns, data, renderRowSubComponent }) {
     headerGroups,
     rows,
     prepareRow,
-    visibleColumns
+    visibleColumns,
+    toggleAllRowsExpanded,
   } = useTable({
     columns,
     data,
@@ -20,6 +21,17 @@ function Table({ columns, data, renderRowSubComponent }) {
   }, 
   useExpanded
   )
+
+  React.useEffect(
+    () => {
+      for (var row of rows) {
+        if (row.original.metadata?.length || 0 > 0) {
+          row.toggleRowExpanded(allExpanded)
+        }
+      }
+    },
+    [allExpanded]
+  );
 
   // Render the UI for your table
   return (
@@ -60,8 +72,8 @@ function Table({ columns, data, renderRowSubComponent }) {
   );
 }
 
-function MaterialsTable({ materialData }) {
-  console.log('this is my materialData ', materialData)
+function MaterialsTable({ materialData, allExpanded }) {
+  console.log(materialData, allExpanded)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const columns = React.useMemo(() => [
     {
@@ -124,6 +136,7 @@ function MaterialsTable({ materialData }) {
         columns={columns}
         data={data}
         renderRowSubComponent={renderRowSubComponent}
+        allExpanded={allExpanded}
       />
   );
 }

--- a/frontend/src/pages/MaterialsTable.js
+++ b/frontend/src/pages/MaterialsTable.js
@@ -4,7 +4,7 @@ import AudioPlayer from '../utils/AudioPlayer';
 import { Link } from 'react-router-dom';
 
 
-function Table({ columns, data, renderRowSubComponent, allExpanded }) {
+function Table({ columns, data, renderRowSubComponent, expandAllChecked }) {
    
   const {
     getTableProps,
@@ -13,7 +13,6 @@ function Table({ columns, data, renderRowSubComponent, allExpanded }) {
     rows,
     prepareRow,
     visibleColumns,
-    toggleAllRowsExpanded,
   } = useTable({
     columns,
     data,
@@ -25,12 +24,12 @@ function Table({ columns, data, renderRowSubComponent, allExpanded }) {
   React.useEffect(
     () => {
       for (var row of rows) {
-        if (row.original.metadata?.length || 0 > 0) {
-          row.toggleRowExpanded(allExpanded)
+        if (row.original.metadata?.length) {
+          row.toggleRowExpanded(expandAllChecked)
         }
       }
     },
-    [allExpanded]
+    [expandAllChecked]
   );
 
   // Render the UI for your table
@@ -56,7 +55,7 @@ function Table({ columns, data, renderRowSubComponent, allExpanded }) {
                     return <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
                   })}
                 </tr>
-                {row.isExpanded && (
+                {row.isExpanded && renderRowSubComponent != null && (
                   <tr>
                     <td colSpan={visibleColumns.length}>
                       {renderRowSubComponent({row})}
@@ -72,8 +71,8 @@ function Table({ columns, data, renderRowSubComponent, allExpanded }) {
   );
 }
 
-function MaterialsTable({ materialData, allExpanded }) {
-  console.log(materialData, allExpanded)
+function MaterialsTable({ materialData, expandAllChecked }) {
+  console.log(materialData, expandAllChecked)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const columns = React.useMemo(() => [
     {
@@ -81,7 +80,7 @@ function MaterialsTable({ materialData, allExpanded }) {
       id: "subexpander",
       // remove arrow if engl
       Cell: ({ row }) => (
-        row.original.metadata && row.original.metadata.length > 0 
+        row.original.metadata?.length
         ? <span {...row.getToggleRowExpandedProps()}> {row.isExpanded ? '▼' : '▶'} </span>
         : <span/>
       ),
@@ -136,7 +135,7 @@ function MaterialsTable({ materialData, allExpanded }) {
         columns={columns}
         data={data}
         renderRowSubComponent={renderRowSubComponent}
-        allExpanded={allExpanded}
+        expandAllChecked={expandAllChecked}
       />
   );
 }

--- a/frontend/src/pages/TextTable.js
+++ b/frontend/src/pages/TextTable.js
@@ -18,8 +18,8 @@ function Table({
    pageCount: controlledPageCount,
    selectValues,
    renderRowSubComponent,
-   allExpanded, 
-   setAllExpanded
+   expandAllChecked,
+   setExpandAllChecked
 }) {
 
    //const { user } = useAuth();
@@ -103,11 +103,10 @@ function Table({
       usePagination,
    )
 
-
    // Listen for changes in pagination and use the state to fetch our new data
    React.useEffect(() => {
-      fetchData({ pageIndex, pageSize, sortBy, filters, globalFilter })
-   }, [fetchData, pageIndex, pageSize, sortBy, filters, globalFilter])
+      fetchData({ pageIndex, pageSize, sortBy, filters, globalFilter, toggleAllRowsExpanded });
+   }, [fetchData, pageIndex, pageSize, sortBy, filters, globalFilter, toggleAllRowsExpanded])
 
    React.useEffect(
       () => {
@@ -118,18 +117,15 @@ function Table({
       [columns, setHiddenColumns]
    );
 
-   React.useEffect(
-      () => {toggleAllRowsExpanded(allExpanded)},
-      [allExpanded, loading]
-   );
-
    // Render the UI for your table
    return (
       <>
          <div className="allExpandToggle">
             <label>
-               <input type="checkbox" onClick={(e) => setAllExpanded(e.target.checked)}/>{' '}
-               {"Expand All"}
+               <input type="checkbox" onChange={(e) => {
+                  setExpandAllChecked(e.target.checked);
+                  toggleAllRowsExpanded(e.target.checked);}}/>
+               {' Expand All'}
             </label>
          </div>
 
@@ -207,7 +203,7 @@ function Table({
                         {row.isExpanded && (
                            <tr>
                               <td colSpan={visibleColumns.length}>
-                                 {renderRowSubComponent({ row, allExpanded })}
+                                 {renderRowSubComponent({ row, expandAllChecked })}
                               </td>
                            </tr>
                         )}
@@ -281,7 +277,6 @@ function Table({
 
 function TextTable(props) {
    let history = useHistory()
-   console.log(props.selectValues)
 
    const columns = React.useMemo(
       () => [
@@ -344,9 +339,9 @@ function TextTable(props) {
 
 
    const renderRowSubComponent = React.useCallback(
-      ({ row, allExpanded }) => (
+      ({ row, expandAllChecked }) => (
          <div>
-            <MaterialsTable materialData={row.original.sourcefiles} allExpanded={allExpanded}/>
+            <MaterialsTable materialData={row.original.sourcefiles} expandAllChecked={expandAllChecked}/>
          </div>
       ),
       []
@@ -356,7 +351,7 @@ function TextTable(props) {
    const [data, setData] = React.useState([])
    const [loading, setLoading] = React.useState(false)
    const [pageCount, setPageCount] = React.useState(0)
-   const [allExpanded, setAllExpanded] = React.useState(false)
+   const [expandAllChecked, setExpandAllChecked] = React.useState(false)
    //const [orderBy, setOrderBy] = React.useState([{'english': 'desc'}, {'nicodemus': 'asc'}])
    const fetchIdRef = React.useRef(0)
    const { client, setAuthTokens } = useAuth();
@@ -385,7 +380,7 @@ function TextTable(props) {
    }
 
 
-   const fetchData = React.useCallback(({ pageSize, pageIndex, sortBy, filters, globalFilter }) => {
+   const fetchData = React.useCallback(({ pageSize, pageIndex, sortBy, filters, globalFilter, toggleAllRowsExpanded }) => {
       // This will get called when the table needs new data
       // You could fetch your data from literally anywhere,
       // even a server. But for this example, we'll just fake it.
@@ -408,6 +403,7 @@ function TextTable(props) {
                   setData(data.texts)
                   setPageCount(Math.ceil(totalCount / pageSize))
                   setLoading(false)
+                  toggleAllRowsExpanded(expandAllChecked)
                })
                .catch((error) => {
                   console.log(error)
@@ -420,7 +416,7 @@ function TextTable(props) {
          }
       }, 1000)
       // eslint-disable-next-line react-hooks/exhaustive-deps
-   }, [history, setAuthTokens])
+   }, [history, setAuthTokens, expandAllChecked])
 
 
    return (
@@ -432,8 +428,8 @@ function TextTable(props) {
             fetchData={fetchData}
             loading={loading}
             pageCount={pageCount}
-            allExpanded={allExpanded}
-            setAllExpanded={setAllExpanded}
+            expandAllChecked={expandAllChecked}
+            setExpandAllChecked={setExpandAllChecked}
          />
       </TableStyles>
    )

--- a/frontend/src/stylesheets/table-styles.js
+++ b/frontend/src/stylesheets/table-styles.js
@@ -119,6 +119,13 @@ const TableStyles = styled.div`
     margin: .5rem;
   }
 
+  .allExpandToggle {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    margin: 1rem;
+  }
+
   .toggle {
     margin: 1rem;
   }


### PR DESCRIPTION
This adds an expand all button to the three existing tables with expansion. 

<img width="663" alt="Screenshot 2023-09-28 at 12 58 44 PM" src="https://github.com/arizona-linguistics/colrc-v2/assets/4073569/9fbb40e3-2684-4212-b33e-04996443522e">
<img width="655" alt="Screenshot 2023-09-28 at 12 58 50 PM" src="https://github.com/arizona-linguistics/colrc-v2/assets/4073569/ae556f64-2fa2-435a-bca6-cf909430bcf9">

The builtin getAllRowsExpandedProps checkbox doesn't do what we want it to.  It doesn't keep state across pages, and it doesn't work for subtables.  It also tends to get confused and have checked be collapsed and unchecked be expanded, so I wrote the logic on my own.  Please let me know if there's a better way to do this!  I feel like I'm passing too many things into the table.

Closes #271 