### PR TITLE
Issue289

### DIFF
--- a/frontend/src/pages/AffixTable.js
+++ b/frontend/src/pages/AffixTable.js
@@ -345,16 +345,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/AffixTableExport.js
+++ b/frontend/src/pages/AffixTableExport.js
@@ -298,16 +298,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/AudioTable.js
+++ b/frontend/src/pages/AudioTable.js
@@ -237,16 +237,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/BibliographyTable.js
+++ b/frontend/src/pages/BibliographyTable.js
@@ -277,16 +277,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/BibliographyTablev8.js
+++ b/frontend/src/pages/BibliographyTablev8.js
@@ -256,16 +256,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => tableInstance.setPageIndex(0)} disabled={!tableInstance.getCanPreviousPage()}>
+        <button onClick={() => tableInstance.setPageIndex(0)} disabled={!tableInstance.getCanPreviousPage()} aria-label={"First Page"}>
           {'<<'}
         </button>{' '}
-        <button onClick={() => tableInstance.previousPage()} disabled={!tableInstance.getCanPreviousPage()}>
+        <button onClick={() => tableInstance.previousPage()} disabled={!tableInstance.getCanPreviousPage()} aria-label={"Previous Page"}>
           {'<'}
         </button>{' '}
-        <button onClick={() => tableInstance.nextPage()} disabled={!tableInstance.getCanNextPage()}>
+        <button onClick={() => tableInstance.nextPage()} disabled={!tableInstance.getCanNextPage()} aria-label={"Next Page"}>
           {'>'}
         </button>{' '}
-        <button onClick={() => tableInstance.setPageIndex(tableInstance.getPageCount() - 1)} disabled={!tableInstance.getCanNextPage()}>
+        <button onClick={() => tableInstance.setPageIndex(tableInstance.getPageCount() - 1)} disabled={!tableInstance.getCanNextPage()} aria-label={"Last Page"}>
           {'>>'}
         </button>{' '}
         <span>

--- a/frontend/src/pages/BrowseRoot.js
+++ b/frontend/src/pages/BrowseRoot.js
@@ -124,16 +124,16 @@ function Table({ columns, data, fetchData }) {
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/ConsonantChart.js
+++ b/frontend/src/pages/ConsonantChart.js
@@ -184,16 +184,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/Contact.js
+++ b/frontend/src/pages/Contact.js
@@ -60,7 +60,7 @@ function Contact() {
   return (
     <Grid textAlign="center" style={{ height: "100vh" }} verticalAlign="middle">
       <Grid.Column style={{ maxWidth: 450 }}>
-        <Logo src={logoImg} />
+        <Logo src={logoImg} alt={"Logo of COLRC"} />
         <Message>
           Contact the COLRC Team with questions or concerns, or to reset your
           password.

--- a/frontend/src/pages/ElicitationsTable.js
+++ b/frontend/src/pages/ElicitationsTable.js
@@ -191,16 +191,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -36,7 +36,7 @@ function Home(props) {
       <Grid textAlign="center">
         <Grid.Column style={{ maxWidth: 450 }}>
           <Message>Welcome to the COLRC!</Message>
-          <Logo src={logoImg} />
+          <Logo src={logoImg} alt={"Logo of COLRC"} />
           <HomeAccordion />
           <Message>
             Are you a site administrator? <Link to="/login">Log in here</Link>

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -21,7 +21,7 @@ function Home(props) {
               </Message>
             </Grid.Row>
             <Grid.Row>
-              <Logo src={logoImg} />
+              <Logo src={logoImg} alt={"Logo of COLRC"} />
             </Grid.Row>
             <Grid.Row>
               <HomeAccordion />

--- a/frontend/src/pages/LogTable.js
+++ b/frontend/src/pages/LogTable.js
@@ -237,16 +237,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -76,7 +76,7 @@ function Login(props) {
   return (
     <Grid textAlign="center" style={{ height: "100vh" }} verticalAlign="middle">
       <Grid.Column style={{ maxWidth: 450 }}>
-        <Logo src={logoImg} />
+        <Logo src={logoImg} alt={"Logo of COLRC"} />
         <Formik
           initialValues={{
             email: "",

--- a/frontend/src/pages/MetadataLexiconTable.js
+++ b/frontend/src/pages/MetadataLexiconTable.js
@@ -183,19 +183,16 @@ function MetadataLexiconTable(props) {
         </table>
 
         <div className="pagination">
-          <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+          <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
             {"<<"}
           </button>{" "}
-          <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+          <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
             {"<"}
           </button>{" "}
-          <button onClick={() => nextPage()} disabled={!canNextPage}>
+          <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
             {">"}
           </button>{" "}
-          <button
-            onClick={() => gotoPage(pageCount - 1)}
-            disabled={!canNextPage}
-          >
+          <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
             {">>"}
           </button>{" "}
           <span>

--- a/frontend/src/pages/MetadataTypesTable.js
+++ b/frontend/src/pages/MetadataTypesTable.js
@@ -165,19 +165,16 @@ function MetadataTypes(props) {
         </table>
 
         <div className="pagination">
-          <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+          <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
             {"<<"}
           </button>{" "}
-          <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+          <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
             {"<"}
           </button>{" "}
-          <button onClick={() => nextPage()} disabled={!canNextPage}>
+          <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
             {">"}
           </button>{" "}
-          <button
-            onClick={() => gotoPage(pageCount - 1)}
-            disabled={!canNextPage}
-          >
+          <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
             {">>"}
           </button>{" "}
           <span>

--- a/frontend/src/pages/OdinsonTable.js
+++ b/frontend/src/pages/OdinsonTable.js
@@ -218,16 +218,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/RootTable.js
+++ b/frontend/src/pages/RootTable.js
@@ -339,16 +339,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/RootTableExport.js
+++ b/frontend/src/pages/RootTableExport.js
@@ -293,16 +293,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/Signup.js
+++ b/frontend/src/pages/Signup.js
@@ -99,7 +99,7 @@ function Signup(props) {
   return (
     <Grid textAlign="center" style={{ height: "100vh" }} verticalAlign="middle">
       <Grid.Column style={{ maxWidth: 450 }}>
-        <Logo src={logoImg} />
+        <Logo src={logoImg} alt={"Logo of COLRC"} />
         <Formik
           initialValues={{
             first: "",

--- a/frontend/src/pages/SpellingList.js
+++ b/frontend/src/pages/SpellingList.js
@@ -278,16 +278,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/StemTable.js
+++ b/frontend/src/pages/StemTable.js
@@ -343,16 +343,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/StemTableExport.js
+++ b/frontend/src/pages/StemTableExport.js
@@ -292,16 +292,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/TextTable.js
+++ b/frontend/src/pages/TextTable.js
@@ -221,16 +221,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>

--- a/frontend/src/pages/UserListTable.js
+++ b/frontend/src/pages/UserListTable.js
@@ -159,19 +159,16 @@ function UserListTable(props) {
         </table>
 
         <div className="pagination">
-          <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+          <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
             {"<<"}
           </button>{" "}
-          <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+          <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
             {"<"}
           </button>{" "}
-          <button onClick={() => nextPage()} disabled={!canNextPage}>
+          <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
             {">"}
           </button>{" "}
-          <button
-            onClick={() => gotoPage(pageCount - 1)}
-            disabled={!canNextPage}
-          >
+          <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
             {">>"}
           </button>{" "}
           <span>

--- a/frontend/src/pages/VowelChart.js
+++ b/frontend/src/pages/VowelChart.js
@@ -185,16 +185,16 @@ function Table({
       </table>
 
       <div className="pagination">
-        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
+        <button onClick={() => gotoPage(0)} disabled={!canPreviousPage} aria-label={"First Page"}>
           {"<<"}
         </button>{" "}
-        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage} aria-label={"Previous Page"}>
           {"<"}
         </button>{" "}
-        <button onClick={() => nextPage()} disabled={!canNextPage}>
+        <button onClick={() => nextPage()} disabled={!canNextPage} aria-label={"Next Page"}>
           {">"}
         </button>{" "}
-        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage}>
+        <button onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} aria-label={"Last Page"}>
           {">>"}
         </button>{" "}
         <span>


### PR DESCRIPTION
Accessibility improvements made:

- Included alt attribute for logo image on homepage, contact, signup, and login page. This means that when using a screenreader, the logo will read "Logo of COLRC" instead of the file name.
- Added aria-labels for table navigation buttons. The buttons will now read as "First Page", "Previous Page", "Next Page", and "Last Page" when using a screen reader.