### PR TITLE
Issue 17 log history front end

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ First, follow the steps to [generate a new SSH Key](https://docs.github.com/en/a
 
 1. Create and/or switch to the directory where you want our application to live. Then, from the command line in that directory, clone this repository:
 
-    `git clone git@github.com:arizona-linguistics/colrc-v2.git`
+    `git clone git@github.com:amyfou/colrc-v2-students.git`
 
 2. Afterward, change to the newly-created directory.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # colrc-v2
 Coeur d'Alene Online Language Resource Center Version 2.0
 
-[![Build Status](https://travis-ci.org/arizona-linguistics/colrc-v2.svg?branch=master)](https://travis-ci.org/arizona-linguistics/colrc-v2)
+[![Build Status](https://travis-ci.org/arizona-linguistics/colrc-v2-students.svg?branch=master)](https://travis-ci.org/arizona-linguistics/colrc-v2-students)
 
 ## Table of Contents
   
@@ -58,14 +58,14 @@ First, follow the steps to [generate a new SSH Key](https://docs.github.com/en/a
 
     `git clone git@github.com:arizona-linguistics/colrc-v2.git`
 
-2. Afterward, change to the newly-created directory and pull to make sure you have all of the current changes to the repository.  Note that the default branch, "main," is the branch you should clone and/or pull.
+2. Afterward, change to the newly-created directory.
 
-    `cd colrc-v2 && git pull`
+    `cd colrc-v2-students`
  
 3. Create the external directories needed to run Odinson: Move up one directory, `cd ..`, and create a new directory named 'data' `mkdir data`.  
 Move into the new directory, `cd data`, and make another directory called 'odinson', `mkdir odinson`. 
 
-Move back to the root of the colrc-v2 directory, `cd ..` to move up one level, then `cd colrc-v2` to move into the root of the colrc-v2 dirctory.
+Move back to the root of the colrc-v2-students directory, `cd ..` to move up one level, then `cd colrc-v2-students` to move into the root of the colrc-v2-students directory.
 
 4. Create your docker override yml file.  The purpose of this file is to tell our application where your external 
 Odinson directory lives, so that it can map a drive to that directory.  The override file will not be copied back into 
@@ -140,23 +140,31 @@ If you get a permissions error when running the script, you can use the command 
  
 7.  At the command line, build our development environment. Depending on your configuration, you may or may not need to `sudo`  The initial build may take a while, but subsequent builds will go faster.
     
-    `docker-compose -f docker-compose.yml -f docker-compose.override.yml up --build` or `docker compose -f docker-compose.yml -f docker-compose.override.yml up --build`
+    `docker-compose -f docker-compose.yml -f docker-compose.override.yml up --build` 
+    
+    or 
+    
+    `docker compose -f docker-compose.yml -f docker-compose.override.yml up --build`
 
-The environment is fully up and running when you see a message that says 'Compiled successfully!'. At that point, you can go to `http://localhost:3000` if you're working on your own machine, or `http://[yourIPaddress]:3000` if you're working on a virtual machine, and you'll be able to access the running application!  The terminal window that you've used for this command will be occupied - it will *not* come back to a command prompt.  This is because the process is not daemonized.  If you want to run the application in a deamonized way, you can add a `-d` flag after `up`.
+The environment is fully up and running when you see a message that says 'Compiled successfully!', followed by this nonsense:
+  `colrc-v2-frontend     | Search for the keywords to learn more about each warning.`
+  `colrc-v2-frontend     | To ignore, add // eslint-disable-next-line to the line before.`
+
+ At that point, you can point a web browser to `http://localhost:3000` if you're working on your own machine, or `http://[yourIPaddress]:3000` if you're working on a virtual machine, and you'll be able to access the running application!  The terminal window that you've used for this command will be occupied - it will *not* come back to a command prompt.  This is because the process is not daemonized.  If you want to run the application in a daemonized way, you can add a `-d` flag after `up`.
     
 9.  If you are working on a remote VM, you'll need to open the hasura console by directing your browser to `[yourIPaddress]:8080/console`. You can find the required admin secret in the docker-compose.yml (hasura_graphql_admin_secret)  file at the project root. Navigate to the data tab, and On each of these four tables:  `audiofiles`, `textfiles`, `textimages`, `elicitationfiles`, under `modify`, you'll find a computed field.  Edit the computed field - which is an SQL statement that tells the machine where it can find our pdf, png, wav and mp3 files.  In the SQL statement is a URL path.  Change the stem of that path (which is probably `localhost`) to `[yourIPaddress]:80`. Then click the button to execute the SQL.
     
 10.  When you want to bring the system down, you can either use control-C from the terminal where the application is running; or use the 'down' button to the right of the container in Docker Desktop's gui, or you can open a new terminal, navigate to the root of the project, and use this command:
 
-    `docker-compose down`
+    `docker compose down`
     
 To relaunch for a new work session, if you haven't done a new pull from the repo, you can just 'up' the system without rebuilding it like this:
 
-    `docker-compose -f docker-compose.yml -f docker-compose.override.yml up`
+    `docker compose -f docker-compose.yml -f docker-compose.override.yml up`
     
 To relaunch after a new pull or significant local changes to i.e. the backend, you can build and then up like this:
 
-    `docker-compose -f docker-compose.yml -f docker-compose.override.yml up --build`
+    `docker compose -f docker-compose.yml -f docker-compose.override.yml up --build`
 
 
 ### Subsequent Pulls
@@ -164,7 +172,7 @@ As we progress in development, this repository will change. To get the most rece
 
 1. Make sure that the development environment is currently not running:
     
-    `docker-compose down`
+    `docker compose down`
     
 2. If there have been changes to [`colrc.sql`](./misc/sql/colrc.sql) since your last pull, delete the database's data folder:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.6"
+# version: "3.6"
 volumes:
   nginx_colrc:
     # external: true

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -26,6 +26,7 @@ import EditRoot from "./pages/EditRoot";
 import DeleteRoot from "./pages/DeleteRoot";
 import AffixHistory from "./pages/AffixHistory";
 import RootHistory from "./pages/RootHistory";
+import StemHistory from "./pages/StemHistory";
 import ElicitationHistory from "./pages/ElicitationHistory";
 import UserList from "./pages/UserList";
 import AddUser from "./pages/AddUser";
@@ -249,6 +250,11 @@ function App(props) {
                 path="/roothistory"
                 component={RootHistory}
                 key="RootHistory"
+              />
+              <PrivateRoute
+                path="/stemhistory"
+                component={StemHistory}
+                key="StemHistory"
               />
               <PrivateRoute
                 path="/elicitationhistory"

--- a/frontend/src/pages/AffixHistory.js
+++ b/frontend/src/pages/AffixHistory.js
@@ -1,4 +1,4 @@
-import React from "react";
+import LogHistory from "./LogHistory";
 import { useLocation } from "react-router-dom";
 import { useAuth } from "../context/auth";
 import { getAffixHistoryByIdQuery } from "./../queries/queries";
@@ -10,31 +10,24 @@ function AffixHistory() {
   const id = search.get("id");
   console.log(id);
 
-  let {
-    loading: affixHistoryLoading,
-    error: affixHistoryError,
-    data: affixHistoryData,
-  } = useQuery(getAffixHistoryByIdQuery, {
-    client: client,
-    variables: { table_name: "affixes", row_data: { id: parseInt(id) } },
-  });
+  let { loading, error, data } = useQuery(getAffixHistoryByIdQuery, {
+      client: client,
+      variables: { table_name: "affixes", row_data: { id: parseInt(id) } },
+    });
 
-  if (affixHistoryLoading) {
+  if (loading) {
     return <div>loading...</div>;
   }
-  if (affixHistoryError) {
+  if (error) {
     return <div>Something went wrong</div>;
   }
 
-  return JSON.stringify(
-    affixHistoryData.audit_logged_actions.map((elem) => {
-      return {
-        action: elem.action,
-        userId: elem.hasura_user["x-hasura-user-id"],
-        english: elem.row_data.english,
-      };
-    })
-  );
+  return (
+    <LogHistory
+      logData={data.audit_logged_actions}
+      tableName="Affix"
+    />
+  )
 }
 
 export default AffixHistory;

--- a/frontend/src/pages/LogHistory.js
+++ b/frontend/src/pages/LogHistory.js
@@ -1,0 +1,114 @@
+/**
+ * Editor: Minh Ngo
+ * Provides a history display for the roots history,
+ * affix history, and stem history
+ */
+
+import {
+  Accordion,
+  AccordionItem,
+  AccordionItemHeading,
+  AccordionItemButton,
+  AccordionItemPanel,
+} from "react-accessible-accordion";
+
+import TableStyles from "./../stylesheets/table-styles";
+
+function LogHistory(props) {
+    let { logData, tableName } = props;
+
+    return (
+        <>
+            <h1>{ tableName } History</h1>
+            {getRows(logData).map((log, i) => (
+            <Accordion key={'log-accordion-' + i} style={{'marginBottom': '20px'}} allowZeroExpanded preExpanded={['log-item-0']}>
+                <AccordionItem uuid={ 'log-item-' + i }>
+                <AccordionItemHeading>
+                    <AccordionItemButton>{ log.timestamp }</AccordionItemButton>
+                </AccordionItemHeading>
+                <AccordionItemPanel>
+                    <div>
+                    { /* User info*/ }
+                    <h3><u>User Information</u></h3>
+                    <h5>User Id: { log.userId }</h5>
+                    <h5>User Role: { log.userRole }</h5>
+
+                    { /* Query info*/ }
+                    <h3><u>Query Information</u></h3>
+                    <h4>ID: { log.id }</h4>
+                    <h5>Action: { resolveAction(log.action) }</h5>
+                    <p style={{'word-wrap': 'break-word'}}>Query: { log.query }</p>
+
+                    { /* Query Edits */ }
+                    <h3><u>Changes</u></h3>
+                    <TableStyles>
+                        <table>
+                        <tbody>
+                            <tr>
+                            <td><b>Element</b></td>
+                            <td><b>Before</b></td>
+                            <td><b>After</b></td>
+                            </tr>
+                            { Object.keys(log.data).map((key, i) => (
+                                <tr key={'log_table' + i}>
+                                <td key={i + "log_data_key"}>{key}</td>
+                                <td key={i + "log_data_value"}>{log.data[key]}</td>
+                                <td key={i + "log_data_change"}>{log.changes[key] ?? "-"}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                        </table>
+                    </TableStyles>
+                    </div>
+                </AccordionItemPanel>
+                </AccordionItem>
+            </Accordion>
+            ))}
+        </>
+    )
+}
+
+function getRows(data) {
+    console.log("DATA" + data )
+    if (!data) return {};
+    let rows = data.map((elem) => {
+        let log = {
+
+        // query data
+        id: elem.event_id,
+        schema: elem.schema_name,
+        relid: elem.relid,
+        session: elem.session_user_name,
+        action: elem.action,
+        query: elem.client_query,
+        userId: elem.hasura_user ? elem.hasura_user["x-hasura-user-id"] : null,
+        userRole: elem.hasura_user ? elem.hasura_user["x-hasura-role"] : null,
+        timestamp: (new Date(elem.action_tstamp_clk)).toISOString(),
+        transactionId: elem.transaction_id,
+        appName: elem.application_name,
+
+        // addr: elem.client_addr,
+
+        // root data
+        data: elem.row_data ?? {},
+        changes: elem.changed_fields ?? {}
+        }
+        return log;
+    })
+    return rows;
+}
+
+function resolveAction(action) {
+    switch (action) {
+        case 'I':
+            return 'Insert'
+        case 'U':
+            return 'Update'
+        case 'D':
+            return 'Delete'
+        default:
+            return action;
+    }
+}
+
+export default LogHistory;

--- a/frontend/src/pages/StemHistory.js
+++ b/frontend/src/pages/StemHistory.js
@@ -1,19 +1,19 @@
 
 import { useLocation } from "react-router-dom";
 import { useAuth } from "../context/auth";
-import { getRootHistoryByIdQuery } from "../queries/queries";
+import { getStemHistoryByIdQuery } from "../queries/queries";
 import { useQuery } from "@apollo/react-hooks";
 import LogHistory from "./LogHistory";
 
-function RootHistory(props) {
+function StemHistory(props) {
   const { client } = useAuth();
   const search = new URLSearchParams(useLocation().search);
   const id = search.get("id");
   console.log(id);
 
-  let { loading, error, data } = useQuery(getRootHistoryByIdQuery, {
+  let { loading, error, data } = useQuery(getStemHistoryByIdQuery, {
     client: client,
-    variables: { table_name: "roots", row_data: { id: parseInt(id) } },
+    variables: { table_name: "stems", row_data: { id: parseInt(id) } },
   });
 
   if (loading) {
@@ -28,10 +28,10 @@ function RootHistory(props) {
     <>
       <LogHistory
         logData={data.audit_logged_actions}
-        tableName="Roots"
+        tableName="Stem"
       />
     </>
   )
 }
 
-export default RootHistory;
+export default StemHistory;

--- a/frontend/src/queries/queries.js
+++ b/frontend/src/queries/queries.js
@@ -660,6 +660,37 @@ export const getAllRootsQuery = gql`
   }
 `;
 
+export const getStemHistoryByIdQuery = gql`
+  query getStemHistoryById($row_data: jsonb!, $table_name: String!) {
+    audit_logged_actions(
+      where: {
+        table_name: { _eq: $table_name }
+        row_data: { _contains: $row_data }
+      }
+      order_by: { action_tstamp_clk: asc }
+    ) {
+      action
+      action_tstamp_clk
+      action_tstamp_stm
+      action_tstamp_tx
+      application_name
+      changed_fields
+      client_addr
+      client_port
+      client_query
+      event_id
+      hasura_user
+      relid
+      row_data
+      schema_name
+      session_user_name
+      statement_only
+      table_name
+      transaction_id
+    }
+  }
+`;
+
 export const getRootHistoryByIdQuery = gql`
   query getRootHistoryById($row_data: jsonb!, $table_name: String!) {
     audit_logged_actions(


### PR DESCRIPTION
Adds a log history page that works as a component for the Roots, Stems, and Affixes history.

Creates the StemHistory.js page, links a route to it, and sets up a query in queries.js to get necessary information.

Displays most of the entry log data, with some dynamic flexibility on the data structure of the collections that the queries affect.